### PR TITLE
Create Complaints Procedure page with noindex and link

### DIFF
--- a/src/pages/complaints.md
+++ b/src/pages/complaints.md
@@ -1,0 +1,103 @@
+---
+title: Complaints Procedure
+description: Renegade Electrical complaints procedure and customer service standards
+permalink: /complaints/
+layout: page.html
+noindex: true
+---
+
+# Complaints Procedure
+
+A complaint is any expression of dissatisfaction by our customers where they want us to do something about it.
+
+We always aim to provide a high standard of care in all our products and services. Where a customer has a complaint, we will consider it and try to find an agreed course of action to resolve the complaint quickly and effectively, in a fair and honest way, to the customer's satisfaction.
+
+## Who Can Complain
+
+Anyone affected by Renegade Electrical's products or services can make a complaint.
+
+A representative may complain for the affected person if they:
+
+- have died
+- cannot make a complaint themselves, or
+- have given consent for the representative to act on their behalf
+
+If you are not happy about making a complaint yourself and you do not know someone who can talk or write to us on your behalf, we will be happy to find someone from an independent organisation to act as an advocate for you.
+
+## Methods Of Complaint
+
+You can complain:
+
+- in person
+- by telephone
+- through an advocate or representative
+- by letter
+- by email
+
+## Responsibility
+
+The Managing Director has overall responsibility for dealing with all complaints made about Renegade Electrical products and services.
+
+We will provide, as far as is reasonably practical:
+
+- any help you need to understand the complaints procedure; or
+- advice on where you may get that help.
+
+## Time Limits
+
+You should complain as soon as you can after the date on which the event occurred or came to your notice. If you complain more than six months later, we may not be able to investigate properly. But we shall also consider whether you had good reason for not making the complaint sooner and whether, despite the delay, it is still possible to investigate the complaint effectively and fairly.
+
+## The Procedure
+
+1. We will take the details of the complaint and record them in our Complaints Log.
+2. We will inform the customer that we will do our best to resolve the complaint but that they have a right to pursue the complaint if we cannot reach a satisfactory resolution, see paragraph below "Further Steps".
+3. For complaints by phone, if we can't resolve the matter immediately we will ask the customer to put the complaint in writing, in an email or letter, so that there is a clear record for everybody. We will offer help with if the customer needs it.
+4. If necessary, we may have to ask the customer to provide us with paperwork or other material. We will note anything received from the customer in the Complaints Log.
+5. If we need to inspect a solar PV system, products or visit the customer to investigate the complaint, we will do so within 7 days of receiving the complaint. If the customer is without heating or hot water as a result of the situation that led to the complaint, we will attend their property within 24 hours.
+6. If a visit is necessary, we will let the customer know the outcome as soon as possible after the visit. We will also record this in the Complain Log.
+7. We will keep a note of contact made, or attempted contacts, to and from the customer while we are trying to resolve the complaint, including telephone conversations.
+8. We will respond to the customer with our findings and a summary of actions/communications within 10 working days of receiving the complaint.
+9. Whenever we can, we will aim to sort the complaint out more quickly than this and informally, for example with a phone call to give advice that solves the problem. We will still log complaints resolved in this way.
+10. We will not take, or threaten to take, action against a customer through the courts without first trying to solve the problem as set out here and in Renewable Energy Consumer Code's dispute resolution process.
+11. We will regularly review the Complaints Log, to identify any actions we may need to take to prevent complaints recurring.
+
+## Further Steps
+
+If we cannot resolve a complaint and the customer is not satisfied with the remedy offered, we will advise where they can pursue their complaint.
+
+### MCS Certification Body
+
+If the complaint is partly or wholly about technical aspects of the installation of a solar PV system, we will direct them to our MCS installer certification body:
+
+The MCS Helpdesk operates Monday – Friday, 9.00am – 4.30pm. The Helpdesk is closed on bank holidays.
+
+- **Phone:** 0333 103 8130
+- **Email:** hello@mcscertified.com
+- **Website:** [mcscertified.com/about-us/contact-us](https://mcscertified.com/about-us/contact-us/)
+
+### Renewable Energy Consumer Code (RECC)
+
+If the complaint is partly or wholly about the customer service aspects of the installation of a solar PV system we will direct them to our consumer code body the Renewable Energy Consumer Code:
+
+The RECC dispute resolution process is set out in the 'How to Complain' section of the RECC website: [recc.org.uk/consumers/how-to-complain](https://www.recc.org.uk/consumers/how-to-complain)
+
+### Energy Performance Certificates
+
+If the complaint is partly or wholly about an Energy Performance Certificate, we will direct them to the Energy Assessor Accreditation Scheme.
+
+- **Phone:** 0300 123 1234
+- **Website:** [accreditationscheme.co.uk](https://www.accreditationscheme.co.uk)
+
+We will cooperate with the scheme complaint-handlers to assist them to resolve the complaint.
+
+**Please note:** schemes will not normally investigate a complaint until we have had an opportunity to respond and resolve matters.
+
+---
+
+## Contact Information
+
+**Ashley Merritt**
+Renegade Electrical
+**Email:** renegadeelectrical99@gmail.com
+**Phone:** 07868643147
+**Website:** [renegade-solar.co.uk](https://www.renegade-solar.co.uk/)

--- a/src/pages/documents.md
+++ b/src/pages/documents.md
@@ -77,6 +77,12 @@ Listed on Green Economy's curated marketplace of trusted green technology provid
 
 ---
 
+## Consumer Protection
+
+**[View our Complaints Procedure](/complaints/)** for information about our customer service standards and complaint resolution process.
+
+---
+
 ## Ready to Work with a Fully Certified Installer?
 
 All our certifications demonstrate our commitment to quality workmanship, consumer protection, and professional standards.


### PR DESCRIPTION
## Summary
- Adds a new Complaints Procedure page with noindex meta to guide customers on the complaint process
- Adds a link to the Complaints page from the Documents page under Consumer Protection for easy access
- Content mirrors our standard complaint-handling process and includes contact details and escalation paths

## Changes
- New file: src/pages/complaints.md
  - Front matter includes noindex: true and permalink: /complaints/
  - Full Complaints Procedure content (customer service standards, who can complain, methods, responsibilities, timelines, steps, and escalation paths)
- Updated file: src/pages/documents.md
  - Added a Consumer Protection section with a link to the Complaints Procedure:
    - [View our Complaints Procedure](/complaints/)

## Why
- Provides a formal, customer-friendly complaints process on the site
- Improves discoverability by linking from the Documents page to the Complaints page
- Ensures search engines are informed not to index the page via front matter, aligning with our content strategy

## Test plan
- Build and serve the site, then verify:
  - The Complaints page is accessible at /complaints/ and renders the full procedure
  - The Complaints page includes a meta robots tag honoring noindex (as per front matter)
  - The Consumer Protection section on the Documents page contains a link labeled "View our Complaints Procedure" pointing to /complaints/
- Manual checks:
  - Ensure the page content is readable and sections render correctly
  - Confirm the link from Documents to Complaints works and does not lead to a 404

## Notes
- No logic changes; this is content-focused
- If needed, adjust wording to reflect any future regulatory changes or updates to the escalation process

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ee8e2b99-1014-4a90-92c9-6b4252656a5a