### PR TITLE
Sync .pages.yml with services markdown fields

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -59,11 +59,12 @@ content:
     fields:
       # Main Content
       - { name: title, type: string, label: Service Title, required: true }
-      - { name: snippet, type: string, label: Short Description, required: true }
+      - { name: snippet, type: string, label: Short Description }
+      - { name: link_title, type: string, label: Link Title }
+      - { name: heading, type: string, label: Page Heading }
       - name: icon
         type: image
         label: Service Icon
-        required: true
         options:
           media: icons
           path: src/assets/icons
@@ -73,8 +74,12 @@ content:
       - { name: description, type: string, label: Meta Description }
 
       # System Settings
-      - { name: order, type: number, label: Display Order, required: true }
+      - { name: order, type: number, label: Display Order }
+      - { name: root, type: boolean, label: Root Service Page }
       - { name: location_pages, type: boolean, label: Has Location Pages }
+      - { name: tags, type: string, label: Tags, list: true }
+      - { name: gallery_tags, type: string, label: Gallery Tags, list: true }
+      - { name: redirect_from, type: string, label: Redirect From URLs, list: true }
 
   - name: locations
     label: Locations Pages

--- a/src/services/commercial-solar-installations.md
+++ b/src/services/commercial-solar-installations.md
@@ -5,7 +5,7 @@ description: Commercial solar installations across Greater Manchester. Cut £700
 icon: /assets/icons/commercial-solar.svg
 order: 3
 root: true
-location_pages: false
+location_pages: true
 gallery_tags: [commercial]
 ---
 


### PR DESCRIPTION
## Summary
- Aligns the .pages.yml service content schema with the services markdown
- Introduces optional fields: Short Description (snippet), Link Title (link_title), Page Heading (heading), Root Service Page (root), Tags (tags), Gallery Tags (gallery_tags), and Redirect From URLs (redirect_from)
- Removes the required constraint on the Service Icon and Display Order
- Enables location pages flag for the commercial installations service in its Markdown

## Changes

### .pages.yml
- Update content schema for services:
  - snippet (Short Description): now optional
  - link_title (Link Title): new field
  - heading (Page Heading): new field
  - icon: previously required; now not required
  - order (Display Order): now optional
  - root (Root Service Page): new boolean field
  - location_pages (Has Location Pages): existing field remains
  - tags (Tags): new list of strings
  - gallery_tags (Gallery Tags): new list of strings
  - redirect_from (Redirect From URLs): new list of strings

### Service Markdown
- Commercial solar installations: location_pages: false -> true to reflect location-based pages

## Testing
- Build the site to ensure pages render with the updated fields
- Verify the admin interface shows the new/optional fields with correct labels
- Confirm commercial-solar-installations now uses location pages

## Notes
- No data migrations required

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b39e2357-7394-4751-a159-cde3af3bc71e