### PR TITLE
Add Oldham market research and expansion strategy document

### DIFF
--- a/OLDHAM-MARKET-RESEARCH.md
+++ b/OLDHAM-MARKET-RESEARCH.md
@@ -172,93 +172,218 @@ Each of these could then have their own service sub-pages. Saddleworth in partic
 
 ---
 
-## 5. Questions to Ask About Solar Installs in Oldham
+## 5. Research Findings & Questions for Ashley
 
-These questions will help gather first-hand knowledge to create authentic, detailed content for the Oldham pages. The answers will differentiate the content from generic competitor pages.
+We've split this into two parts. **Part A** covers the factual/technical stuff we've already researched — things like how east-west roofs affect output, what stone slate roofs mean for installation, conservation area rules, etc. These are included so Ashley can see what we've found, correct anything that's wrong, and add his own practical experience on top.
 
-### Your Experience in the Oldham Area
+**Part B** is the stuff only Ashley can answer — his experience in the area, pricing, how he'd pitch to customers, photos he might have, etc.
 
-1. Have you done any installations in Oldham borough (beyond Failsworth)? If so, where — Chadderton, Royton, Shaw, Lees, Saddleworth, central Oldham? What were the properties like?
+---
 
-2. What's your experience with the typical Victorian terraced houses you find in Oldham — the old Accrington red-brick mill worker terraces? Do they present any particular challenges for solar (roof condition, access, shading from neighbouring chimneys)?
+### Part A: What We've Researched (For Ashley to Confirm, Correct, or Add To)
 
-3. Have you worked on any properties in the Saddleworth villages (Uppermill, Greenfield, Delph, Dobcross, Diggle)? These are quite different from central Oldham — stone-built, rural, potentially conservation area. Any experience or thoughts?
+#### East-West Facing Roofs (Many Oldham Terraces)
 
-4. Failsworth is technically part of the Oldham borough. You've done work there — are there specific photos or stories from those jobs we could reference on the new Oldham pages to show you're already active in the area?
+Many Oldham terraces have roofs running parallel to the street, giving east and west slopes rather than south-facing. Our research says:
 
-5. Have you had any enquiries from Oldham that didn't convert? If so, what were the common reasons? Price comparison with other local installers? Property suitability issues?
+- East or west facing panels produce **15-20% less per panel** than south-facing (Energy Saving Trust, MCS data).
+- But you can install panels on **both slopes**, potentially doubling the available roof area and producing **more total energy** than south-only.
+- East-west setups **match household usage better** — morning generation (breakfast, getting ready) and evening generation (cooking, returning home) rather than peak at midday when nobody's in.
+- This means **higher self-consumption** and potentially less need for battery storage.
+- On flat roofs, east-west arrays can generate **~30% more total power** than south-facing on the same footprint.
 
-### Property Types & Technical Considerations
+**Question for Ashley:** Does this match your experience? For a typical Oldham terrace with east-west slopes, do you usually recommend panels on both sides? Roughly how many panels can you fit on each slope of a 2-bed or 3-bed mid-terrace?
 
-6. Oldham has the highest proportion of terraced houses in Greater Manchester (nearly 49% of sales). For a typical 2-bed or 3-bed terrace in places like Chadderton or Royton, what size system would you typically recommend? How many panels can you realistically fit?
+#### Elevation & Wind Exposure
 
-7. Many Oldham terraces have the roof running parallel to the street, meaning east-west facing slopes rather than south-facing. How much does this affect output in practice? Do you ever recommend panels on both east and west slopes?
+Oldham sits higher than Manchester — central Oldham around 200m, parts of Saddleworth 300-400m+. Our research says:
 
-8. Chimney stacks on terraced houses can cause shading issues. How do you handle this — panel-level optimisers, micro-inverters, or just positioning around the shading? Are there terraces where it's genuinely not worth doing?
+- The altitude effect on solar output is **negligible** at these elevations — maybe 1-2% gain from thinner atmosphere, but offset by more cloud cover on the Pennine slopes.
+- **Wind loading is the real concern**, not yield. MCS 012 requires altitude correction factors for wind load calculations. Exposed hilltop sites get significantly higher design wind pressures.
+- Panels must be fixed to **rafters, not tiling battens** — critical at exposed sites.
+- If roof loading increases by 15%+, formal Building Regulations approval (Part A) is needed.
 
-9. Oldham sits on higher ground than Manchester (some areas are 200m+ above sea level). Does the elevation, wind exposure, or weather pattern make any practical difference to installations or panel performance?
+**Question for Ashley:** Have you had to spec heavier-duty fixings for exposed properties in areas like Saddleworth or upper Oldham? Does the wind exposure add meaningful cost to an installation, or is it just part of your standard calculations?
 
-10. A lot of the older terraced stock in Oldham has stone slate roofs rather than modern tiles. Does this affect installation — different fixings, weight considerations, any specialist requirements?
+#### Stone Slate Roofs
 
-11. Some Oldham properties still have older electrical systems — old fuse boxes, no RCD protection. How often do you encounter this, and what's the typical additional cost for a consumer unit upgrade alongside a solar install?
+Many older properties in Saddleworth and parts of Oldham have Yorkstone/stone flag roofs. Our research says:
 
-12. For the larger detached homes in Saddleworth, what size systems are you typically recommending? 6kW? 8kW? More? What kind of savings can these homeowners expect?
+- Solar **can** be installed on stone slate, but it's **significantly more complex**.
+- Standard shortcut systems (e.g. Solar Limpets) **explicitly exclude stone slate**. You need traditional rafter-mount brackets with lead flashing.
+- Slates must be **temporarily removed** to access rafters — risk of cracking irreplaceable stone slates.
+- Stone slate weighs ~125 kg/m² vs ~45 kg/m² for concrete tiles. However, the proportional load increase from panels (~10-15 kg/m²) is smaller on an already-heavy roof.
+- Installation takes **up to 5 days** (vs 1-2 for standard roofs).
+- Expect a **30%+ cost premium** over standard installations.
+- Sourcing **replacement stone slates** if any are damaged is difficult and expensive.
 
-### Battery Storage & EV Specific to Oldham
+**Question for Ashley:** Have you done any installations on stone slate roofs? Is the 30% premium roughly right, or is it more/less in practice? Would you be comfortable advertising this as something you can do, or would you rather steer these customers toward an in-roof system or an alternative approach?
 
-13. For Oldham's terraced houses with lower energy consumption, does a battery still make financial sense, or would you sometimes recommend panels only? What's the threshold where you'd say a battery isn't worth it?
+#### Consumer Unit Upgrades on Older Terraces
 
-14. Many Oldham terraces have no driveway — just street parking or a rear yard. How does this affect EV charger installations? Do you run cables through to rear yards? What about charging from a front-mounted charger when you park on the street?
+Many Oldham terraces still have old fuse boxes. Our research says:
 
-15. For commuters from Oldham into Manchester (common route — 20-30 minute drive or Metrolink tram), what kind of daily charging costs would a typical EV use? How does this compare to petrol for the same commute?
+- A consumer unit upgrade costs approximately **£400-£600** in the North of England.
+- It's **not technically mandatory** in all cases, but practically required on most older terraces — BS 7671 Section 712 requires the existing board to safely accommodate the new PV circuit, and MCS-certified installers can't certify against a non-compliant board.
+- Properties built **before 2008** typically lack RCD protection that meets current standards.
+- Since September 2022, **Type AC RCDs are no longer permitted** — consumer units need Type A RCCBs or RCBOs.
+- Surge protection (SPDs) is now effectively mandatory.
+- On older terraced stock, the majority — likely **well over half** — will need an upgrade.
 
-### Commercial & Landlord Market
+**Question for Ashley:** Is the £400-£600 figure right for what you charge? How often do you encounter this on the kind of terraces you'd see in Oldham — more like 50% of jobs, or closer to 80%+? Do you include this as a line item in your standard quotes, or is it an additional cost that comes up after the survey?
 
-16. Oldham has a significant landlord/buy-to-let market, particularly in central areas. Do landlords enquire about solar? Is there a business case for a landlord to install solar on a rental property, or does it only make sense if they're paying the electricity bill?
+#### Battery Viability for Small Terraces
 
-17. Oldham town centre still has old mill buildings and commercial/industrial units. Have you done any solar installs on these types of properties? What are the opportunities and challenges?
+For a typical 2-bed Oldham terrace using 2,500-3,000 kWh/year:
 
-18. Are there types of commercial businesses in Oldham where solar would be a particularly good fit — takeaways, corner shops, small manufacturing, warehouses?
+- On a **standard flat-rate tariff**, battery payback is likely **10-12+ years** — uncomfortably close to the battery's warranty lifespan.
+- On a **time-of-use tariff** (Octopus Go/Agile), payback drops to **7-10 years**, which is within warranty.
+- Expert consensus: for low-consumption homes on standard tariffs, **panels first, battery later** is the better advice.
+- A **4-5 kWh battery** is the maximum useful size at this consumption level — anything larger is underutilised.
+- Self-consumption without a battery is already high if the household uses energy during the day (e.g. working from home).
+- The money is often better spent **maximising panel capacity first**, especially where roof space is limited.
 
-### Pricing & Competition
+**Question for Ashley:** Do you agree with the "panels first, battery later" advice for small terraces? Or do you find that most customers want the battery regardless? What's your honest threshold — when do you tell someone a battery isn't worth it for them? And does the Octopus partnership affect your recommendation (i.e. do you always recommend a time-of-use tariff with a battery)?
 
-19. How does your pricing compare to the competitors active in Oldham? Greentech Renewables in Bury advertise 0% finance — do you offer anything similar, or do you compete on price/quality/service?
+#### EV Commuting Costs (Oldham to Manchester)
 
-20. E-Verve Energy advertises solar in Greater Manchester "from £3,395." Is that realistic for a decent system, or is it a loss-leader / minimal spec quote? What would a typical Renegade installation cost for an Oldham terrace?
+For a typical Oldham-to-Manchester commute (~9 miles each way, 250 working days):
 
-21. Trust Renewables position themselves as a social enterprise. Does that angle resonate with customers, or do people ultimately choose on price and reviews?
+| Scenario | Annual Cost | Daily Cost |
+|----------|-----------|-----------|
+| **Petrol (40 mpg)** | ~£675 | ~£2.70 |
+| **EV, home standard tariff** | ~£315-360 | ~£1.25 |
+| **EV, off-peak tariff (7p/kWh)** | ~£90-135 | ~£0.32 |
+| **EV, home solar** | ~£0 | ~£0 |
+| **EV, public rapid** | ~£900-1,125 | ~£3.42 |
 
-22. Some competitors offer in-roof (integrated) solar panels. Do you offer these? Are they popular for terraced houses where aesthetics matter?
+- A typical daily commute needs ~4.5 kWh — easily covered by surplus solar from a 4kW+ system in summer months.
+- Smart strategy: export solar at ~15p/kWh and charge overnight at 7p/kWh on an EV tariff, netting 8p/kWh profit per unit.
+- Public rapid charging is **more expensive than petrol** — not viable for daily commuting.
 
-23. Logic Renewables are based right in the Oldham area (Shaw/Royton). Do you see them as your main local competitor? Any thoughts on how to differentiate?
+**Question for Ashley:** These are the numbers we'd use on the EV charger pages. Anything look off? Do you have a go-to example or real customer story you use when explaining EV savings?
 
-### Grants, Schemes & Local Knowledge
+#### Landlord Business Case
 
-24. Oldham Council has active ECO4 and Local Authority Flex schemes offering grants for energy improvements. Have any of your customers used these? How does the process work — does the homeowner apply separately, or can you help facilitate?
+Oldham has a big buy-to-let market. Our research says the business case is strong and getting stronger:
 
-25. Are you aware of the Oldham Green New Deal initiatives — the community solar schemes, the Wrigley Head solar farm, the Energy Futures project? Could any of this be referenced in the content to show alignment with the council's direction?
+- **EPC C deadline confirmed**: All privately rented properties in England must be EPC C by **1 October 2030**. 52% of rental stock is currently below C. Cost cap is £10,000 per property.
+- Solar panels improve EPC by approximately **18 points** (roughly one band, e.g. D to C).
+- Landlords **can claim SEG payments** even when tenants use the electricity — the SEG contract is separate from the supply contract.
+- Solar adds **6-7% to property value** (Swansea University 2024 study analysing ~5 million Zoopla listings).
+- 0% VAT on solar until **March 2027**.
+- The **Warm Homes: Local Grant** offers up to £15,000 per eligible property (EPC D-G, income ≤£36,000). First property fully funded; subsequent properties require 50% landlord contribution.
 
-26. Oldham Community Power has put solar on local schools. Have you ever done any public sector or community installations? Would you be interested in this kind of work?
+**Question for Ashley:** Do you get many enquiries from landlords? The EPC C 2030 deadline seems like a big opportunity — are you seeing landlords starting to act on this, or is it still on the horizon for most? Would you be open to us positioning you as someone who can help landlords hit EPC C specifically?
 
-27. For Oldham properties in conservation areas (parts of Saddleworth, some central Oldham areas), what are the practical limitations for solar? Do you ever recommend standalone battery systems for properties where roof panels aren't possible?
+#### ECO4 & LA Flex Grants
 
-### Content & Marketing
+Our research turned up an important limitation:
 
-28. What would you say to an Oldham homeowner who's on the fence about solar — maybe they think Manchester doesn't get enough sun, or that their terraced house is too small?
+- ECO4 **does** fund solar PV, but **only where the property has or is getting electric heating or a heat pump**. Solar alone on a gas-heated home does not qualify.
+- Oldham Council runs an active LA Flex scheme. Income threshold: **£31,000 gross household income**. Also covers health/vulnerability routes (GP/NHS referral for cold-related conditions).
+- The process is **installer-facilitated** — the installer checks eligibility, submits the application, and the grant is paid directly to the installer. Homeowner doesn't apply to government.
+- Oldham's approved delivery partners are **0800 Repair** and **Improveasy**.
+- The scheme runs until **December 2026**, but supplier budgets may run out earlier.
+- Eligible measures in Oldham include solar panels, solar batteries, and air source heat pumps.
 
-29. Is there anything specific about Oldham properties or the local area that you'd want highlighted on the website — something that national companies wouldn't know or bother mentioning?
+**Question for Ashley:** Given the electric-heating-only restriction, is ECO4 relevant for your typical customers, or is it mainly useful when you're doing a heat pump + solar package? Are you registered with Oldham Council's scheme, or would that be worth pursuing? Have any of your customers gone through ECO4?
 
-30. If a customer in Chadderton or Royton calls you, how quickly could you typically get out there for a survey? Same day? Next day? Within the week?
+#### Conservation Areas (Saddleworth & Central Oldham)
 
-31. Do you have any existing Oldham-area customers who might provide testimonials or case studies we could use (with their permission)?
+Several areas in Saddleworth and central Oldham are conservation areas. Our research says:
 
-32. Are there any particular panel brands or battery systems you'd recommend specifically for Oldham's terraced houses — maybe something compact or particularly efficient for limited roof space?
+- **Roof-mounted solar panels are generally permitted development** in conservation areas — no planning permission needed, provided panels don't protrude more than 200mm from the roof slope and don't exceed the ridge line.
+- **Wall-mounted panels need planning permission** if the wall faces a public highway.
+- **December 2023 relaxation**: Flat roof solar is now PD in conservation areas (up to 600mm protrusion), reversing the previous restriction.
+- **Listed buildings are completely different** — always need Listed Building Consent, regardless of whether they're in a conservation area or not.
+- No evidence of a specific Article 4 Direction in Saddleworth removing solar PD rights, but this should be verified with Oldham Council.
+- Recommendation: apply for a **Lawful Development Certificate (LDC)** before installation in conservation areas, as a belt-and-braces measure.
 
-33. For Saddleworth specifically — these are often premium properties with higher energy bills. Would you pitch the service differently here compared to, say, a 2-bed terrace in central Oldham?
+**Question for Ashley:** Have you done any installations in conservation areas? Do you routinely apply for LDCs, or is that overkill in practice? For listed buildings in Saddleworth where roof panels aren't possible, would you recommend a ground-mounted system or a standalone battery instead?
 
-34. The Metrolink tram runs through Oldham (Shaw, Derker, Oldham Mumps, Oldham King Street, Freehold, South Chadderton, Hollinwood). Is there any angle around EV chargers and public transport — e.g., people who drive to a tram stop and park?
+#### Metrolink Tram (Corrected Info)
 
-35. What's the single strongest reason someone in Oldham should choose Renegade over a competitor who's already based in the area?
+The original draft listed 7 stops — the actual count is **10** through the Oldham borough (north to south):
+
+1. Shaw and Crompton
+2. Derker
+3. Oldham Mumps
+4. Oldham Central
+5. Oldham King Street
+6. Westwood
+7. Freehold
+8. South Chadderton
+9. Hollinwood
+10. Failsworth
+
+**Four stops have park-and-ride**: Hollinwood (~195 spaces), Oldham Mumps (~254 spaces), Derker (smaller), Shaw and Crompton (limited). Journey time from Oldham Central to Manchester city centre is ~32 minutes.
+
+This is relevant for the EV charger page — commuters who drive to a park-and-ride stop and leave their car all day are a natural audience for home EV charging. Charge overnight on off-peak, drive to the tram, come home to a charged car. No need for expensive public chargers.
+
+---
+
+### Part B: Questions Only Ashley Can Answer
+
+These are the things we can't Google — your experience, your opinions, your stories. These are what will make the Oldham pages sound like they're written by someone who actually knows the area, not a content mill.
+
+#### Your Experience in the Oldham Area
+
+1. Have you done any installations in Oldham borough beyond Failsworth? If so, where — Chadderton, Royton, Shaw, Lees, Saddleworth, central Oldham? What were the properties like?
+
+2. What's your experience with the typical Oldham terraces — the old Accrington red-brick mill worker houses? Any particular challenges you've encountered (roof condition, access between tight rows, shading from neighbouring chimneys)?
+
+3. Have you worked on any properties in the Saddleworth villages (Uppermill, Greenfield, Delph, Dobcross, Diggle)? These are a different world from central Oldham — stone-built, rural, bigger properties. Any experience or thoughts?
+
+4. Are there specific photos or stories from the Failsworth jobs we could reference on the Oldham pages to show you're already active in the borough?
+
+5. Have you had any enquiries from Oldham that didn't convert? What were the reasons — price comparison with local competitors, property suitability issues, something else?
+
+#### Technical (Your Specific Approach)
+
+6. For a typical 2-bed or 3-bed terrace in Chadderton or Royton, what size system would you recommend? How many panels can you realistically fit on one slope?
+
+7. Chimney stacks on terraced houses cause shading. What's your standard approach — panel-level optimisers, micro-inverters, or positioning around the shading? At what point do you tell someone their roof genuinely won't work?
+
+8. Many Oldham terraces have no driveway — just street parking or a rear yard. How do you handle EV charger installations in that situation? Do you run cables through to rear yards, or is a front-mounted charger with a cable across the pavement an option?
+
+9. For the larger detached homes in Saddleworth, what size systems are you typically recommending? 6kW? 8kW? More?
+
+#### Pricing & Competition
+
+10. How does your pricing compare to the competitors active in Oldham? Greentech Renewables in Bury advertise 0% finance — do you offer anything similar, or is your pitch purely price/quality/service?
+
+11. E-Verve Energy advertises solar in Greater Manchester "from £3,395." Is that realistic for a usable system, or is it a loss-leader / bare-minimum spec? What would a typical Renegade installation cost for an Oldham terrace?
+
+12. Trust Renewables position themselves as a social enterprise — "people and planet before profit." Does that kind of angle resonate with customers in practice, or do people ultimately choose on price and reviews?
+
+13. Some competitors offer in-roof (integrated) solar panels. Do you offer these? Are they popular for terraced houses where aesthetics matter, or do most people not care?
+
+14. Logic Renewables are based right in Oldham (Shaw/Royton) — they're the most genuinely local competitor. Any thoughts on how to differentiate against someone who's actually based there?
+
+#### Commercial & Local Opportunities
+
+15. Oldham town centre still has old mill buildings and commercial/industrial units. Have you done any solar installs on these types of properties? What are the opportunities and challenges with them?
+
+16. Are there types of commercial businesses in Oldham where solar would be a particularly good fit? Takeaways running fryers all day, small manufacturers, cold storage, warehouses with big flat roofs?
+
+17. Oldham Community Power has put solar on local schools. Have you ever done public sector or community installations? Would you be interested in this kind of work?
+
+#### Content & Marketing
+
+18. What would you say to an Oldham homeowner who's on the fence — thinks Manchester doesn't get enough sun, or that their terraced house is too small? What's your real-life comeback?
+
+19. Is there anything specific about Oldham properties or the local area that you'd want highlighted — something national companies wouldn't know or bother mentioning?
+
+20. If a customer in Chadderton or Royton calls, how quickly can you typically get out for a survey? Same day? Next day? Within the week?
+
+21. Do you have any existing Oldham-area customers who might provide testimonials or case studies (with permission)?
+
+22. Any particular panel brands or battery systems you'd recommend for Oldham's terraced houses — compact panels, high-efficiency options for limited roof space?
+
+23. For Saddleworth specifically — premium properties, higher energy bills. Would you pitch the service differently there compared to a 2-bed terrace in central Oldham?
+
+24. What's the single strongest reason someone in Oldham should choose Renegade over a competitor who's already based in the area?
 
 ---
 

--- a/OLDHAM-MARKET-RESEARCH.md
+++ b/OLDHAM-MARKET-RESEARCH.md
@@ -1,0 +1,295 @@
+# Oldham Market Research & Page Plan for Renegade Solar
+
+## 1. The Oldham Opportunity
+
+### Why Oldham Makes Sense
+
+- **Proximity**: Only 9 miles / 13 minutes' drive from Prestwich. Closer than many areas already served (e.g. Altrincham, Stockport, Bramhall, Marple).
+- **No current coverage**: Renegade has zero Oldham pages. The only nearby overlap is a Failsworth solar page (Failsworth is technically in the Oldham borough). There's a gap to fill.
+- **Large borough**: Oldham Metropolitan Borough has ~96,000 households. It's a whole borough with multiple distinct towns and neighbourhoods, each worth targeting.
+- **Housing stock dominated by terraces**: 48.8% of property sales are terraced houses — the highest proportion in Greater Manchester. These are bread-and-butter solar installations that Renegade already handles well.
+- **Affordable property = cost-conscious homeowners**: Average terraced house price is £168,080 (30% below UK average). These homeowners feel energy bills more acutely and are prime candidates for solar savings.
+- **Strong council backing for green energy**: Oldham declared a Climate Emergency in 2019 and became the UK's first "Green New Deal Council" in 2020. They secured £20m Levelling Up funding for green initiatives. The council runs Oldham Community Power (solar on schools) and approved a £1.35m solar farm at Wrigley Head. This creates a local culture receptive to solar.
+- **Government grants available**: ECO4 and Local Authority Flex schemes offer grants to households with EPC ratings D-G or low income — many of Oldham's older terraced properties will qualify.
+- **0% VAT on domestic solar**: Until 2027, no VAT on residential solar and battery installations.
+
+### Oldham Neighbourhoods Worth Targeting
+
+| Area | Property Profile | Solar Potential | Notes |
+|------|-----------------|-----------------|-------|
+| **Chadderton** | Mix of terraces and semis, avg £215k | Strong — good mix of roof types | Close to Failsworth (existing page), M60 access |
+| **Royton** | Terraces and semis, area seeing 41.5% price growth over 5 years | Strong — family homes with decent roofs | Growing area, homeowners investing in properties |
+| **Shaw** | Traditional mill town terraces, avg £335k (newer/larger stock) | Good — terraced roofs | Slightly more affluent, willing to invest |
+| **Lees** | Mix of terraces and semis, avg £240k | Good | Close to Saddleworth |
+| **Saddleworth** | More detached/semi homes, avg £393k, most expensive in borough | Excellent — larger roofs, higher energy use, more disposable income | Villages: Uppermill, Greenfield, Delph, Dobcross, Diggle, Denshaw |
+| **Failsworth** | Terraces, close to Manchester, avg ~£180k | Strong — already have a solar page for here | Part of Oldham borough, bridge between Manchester and Oldham |
+| **Oldham Town Centre / Central** | Dense terraced housing, most affordable areas (St Marys £123k, Coldhurst £137k) | Moderate — some shading, tight streets | ECO4 grant candidates, landlord market |
+| **Hollinwood** | Terraces and semis, M60 access, attracting buyers for affordability | Good | Gateway between Manchester and Oldham |
+
+### Key Oldham Stats for Content
+
+- Average household energy bill in Oldham: ~£1,850/year
+- Typical solar savings: £350-£570/year (some sources say up to £740 with grants)
+- A 4kW system in Oldham produces ~3,250 kWh/year
+- Solar adds ~4.1% to property values
+- A typical installation saves 1.3-1.6 tonnes of CO₂/year
+- Smart Export Guarantee pays 5-15p/kWh for exported electricity
+- Most installations fall under permitted development (no planning permission needed)
+
+---
+
+## 2. Competitor Analysis
+
+### Key Competitors Serving Oldham
+
+#### Trust Renewables
+- **Type**: Social enterprise (accredited by Social Enterprise UK)
+- **Base**: Greater Manchester
+- **Services**: Domestic, commercial, utility-scale solar PV, EV charging
+- **Angle**: "People and planet before profit" — social enterprise positioning
+- **Strength**: Community-focused brand, broad coverage including Saddleworth villages
+- **Weakness**: Social enterprise model may mean slower response; less personal than sole trader
+
+#### Greentech Renewables
+- **Base**: Bury (nearby to Renegade)
+- **Services**: Solar PV, battery storage, EV chargers
+- **Reviews**: 100+ five-star reviews on Trustpilot
+- **Strength**: MCS certified, 0% finance offered, strong review count
+- **Weakness**: Based in Bury like Renegade — competing on same turf
+- **Key claim**: 4kW system in Oldham produces ~3,250 kWh/year, saving £480-£600
+
+#### Logic Renewables
+- **Base**: Oldham area (Shaw, Royton, Chadderton)
+- **Services**: Solar PV (on-roof and in-roof), MCS accredited
+- **Strength**: Genuinely local to Oldham, rapid service response
+- **Weakness**: Less online presence/reviews than Greentech
+
+#### Evergen Solar
+- **Base**: Manchester area with consultants across the region
+- **Services**: Residential solar, free home surveys
+- **Strength**: Personalised reports, covers Bolton, Rochdale, Oldham
+- **Weakness**: Broader Manchester focus, not Oldham-specific
+
+#### Atlantic Renewables
+- **Base**: ~12 miles from Oldham
+- **Services**: Solar PV installation
+- **Strength**: Experienced team
+- **Weakness**: Not local — 12 miles away
+
+#### Ranger Electrical Services
+- **Services**: Commercial, industrial, large residential solar
+- **Reviews**: Praised for "neat and tidy" work, "excellent workmanship"
+- **Key claim**: Clients save 50-80% on electricity bills
+- **Strength**: Commercial focus is differentiated
+- **Weakness**: Less focused on standard domestic installs
+
+#### UPS Solar
+- **Base**: National, with teams in Oldham area
+- **Reviews**: Praised for smooth process, competitive pricing
+- **Strength**: Handles DNO, MCS, SEG paperwork
+- **Weakness**: National company — less local knowledge
+
+#### County End Electrical NW
+- **Base**: Manchester/Oldham area
+- **Services**: Solar panels, general electrical
+- **Weakness**: Smaller outfit, less online presence
+
+### Other Players
+- E-Verve Energy (Greater Manchester coverage, from £3,395)
+- Best Solar Discounts (25+ years, hundreds of installations)
+- JWS Renewables (Oldham-based)
+- Panelit Solar
+- 41+ installers listed on Houzz alone
+- 11 on Checkatrade
+- Average installer rating across platforms: 4.98/5
+
+### Market Quality
+The Oldham solar market is competitive with many installers, but most are either:
+1. National companies with local coverage but no genuine local knowledge
+2. Smaller local outfits with fewer reviews/certifications
+3. Based in nearby towns (Bury, Manchester) serving Oldham as part of broader coverage
+
+---
+
+## 3. How Renegade Compares — Competitive Advantages
+
+### Genuine Differentiators
+
+| Factor | Renegade | Typical Competitor |
+|--------|----------|-------------------|
+| **Personal service** | Ashley personally handles survey, design, and installation | Sales team does survey, separate team installs |
+| **Reviews** | 9.86/10 from 100+ Checkatrade reviews | Most have fewer verified reviews |
+| **Certifications** | MCS, NAPIT, TrustMark, HIES, Octopus Trusted Partner | Usually MCS only |
+| **Proximity** | 13 min drive from Prestwich | Many are 12+ miles away |
+| **No salespeople** | Electrician surveys and installs | Sales reps spec jobs |
+| **Local knowledge** | Deep knowledge of NW Manchester property types | Generic approach |
+| **Battery expertise** | Specialises in solar+battery combos | Some only do panels |
+| **EV integration** | Full EV charger service with solar integration | Often separate companies |
+| **Honest advice** | Will say no if solar isn't suitable | Pressure to sell |
+| **Aftercare** | 2 years routine maintenance included | Often nothing post-install |
+
+### Key Messaging Points for Oldham Pages
+
+1. **"Just down the road"** — 13 minutes from Prestwich, no travel charges, genuinely local support
+2. **"One person, start to finish"** — Ashley surveys, designs, installs. No handoffs, no miscommunication
+3. **"We'll tell you if it won't work"** — Honest advice, especially important for Oldham's terraced stock where some properties genuinely aren't suitable
+4. **"All the certifications that matter"** — MCS (for SEG payments), TrustMark, NAPIT, HIES
+5. **"Terraced house specialists"** — Directly relevant given Oldham's 49% terraced housing stock
+6. **"Octopus Energy Trusted Partner"** — Smart tariff integration for maximum savings
+7. **"Already working in the area"** — Failsworth installations already completed
+
+---
+
+## 4. Proposed New Pages
+
+### Location Root Page
+- `src/locations/oldham.md` — Main Oldham landing page (layout: location-root.html)
+
+### Service + Location Pages
+- `src/services/solar-and-battery-installations/oldham.md` — Residential solar in Oldham
+- `src/services/electric-vehicle-charger-installations/oldham.md` — EV chargers in Oldham
+- `src/services/electrical-safety-inspections-eicr/oldham.md` — EICR inspections in Oldham
+- `src/services/commercial-solar-installations/oldham.md` — Commercial solar in Oldham
+
+### Potential Neighbourhood Pages (Phase 2)
+Once the main Oldham pages are established, consider adding location root pages for:
+- `src/locations/chadderton.md`
+- `src/locations/royton.md`
+- `src/locations/shaw.md`
+- `src/locations/lees.md`
+- `src/locations/saddleworth.md`
+
+Each of these could then have their own service sub-pages. Saddleworth in particular is worth targeting early — higher property values, larger roofs, more energy consumption, and homeowners more likely to invest in solar.
+
+### Content Strategy Notes
+
+- The Failsworth solar page already exists and is strong. The new Oldham pages should reference the Failsworth work as proof of local activity.
+- Oldham pages should emphasise terraced house expertise since that's the dominant property type.
+- Saddleworth pages should take a different angle — larger detached homes, higher energy usage, bigger systems, premium positioning.
+- Conservation area guidance is relevant — several areas in Saddleworth and central Oldham have restrictions.
+- The council's Green New Deal and community solar initiatives create a natural hook for content.
+- ECO4 grants are particularly relevant for Oldham's lower-income areas.
+
+---
+
+## 5. Questions to Ask About Solar Installs in Oldham
+
+These questions will help gather first-hand knowledge to create authentic, detailed content for the Oldham pages. The answers will differentiate the content from generic competitor pages.
+
+### Your Experience in the Oldham Area
+
+1. Have you done any installations in Oldham borough (beyond Failsworth)? If so, where — Chadderton, Royton, Shaw, Lees, Saddleworth, central Oldham? What were the properties like?
+
+2. What's your experience with the typical Victorian terraced houses you find in Oldham — the old Accrington red-brick mill worker terraces? Do they present any particular challenges for solar (roof condition, access, shading from neighbouring chimneys)?
+
+3. Have you worked on any properties in the Saddleworth villages (Uppermill, Greenfield, Delph, Dobcross, Diggle)? These are quite different from central Oldham — stone-built, rural, potentially conservation area. Any experience or thoughts?
+
+4. Failsworth is technically part of the Oldham borough. You've done work there — are there specific photos or stories from those jobs we could reference on the new Oldham pages to show you're already active in the area?
+
+5. Have you had any enquiries from Oldham that didn't convert? If so, what were the common reasons? Price comparison with other local installers? Property suitability issues?
+
+### Property Types & Technical Considerations
+
+6. Oldham has the highest proportion of terraced houses in Greater Manchester (nearly 49% of sales). For a typical 2-bed or 3-bed terrace in places like Chadderton or Royton, what size system would you typically recommend? How many panels can you realistically fit?
+
+7. Many Oldham terraces have the roof running parallel to the street, meaning east-west facing slopes rather than south-facing. How much does this affect output in practice? Do you ever recommend panels on both east and west slopes?
+
+8. Chimney stacks on terraced houses can cause shading issues. How do you handle this — panel-level optimisers, micro-inverters, or just positioning around the shading? Are there terraces where it's genuinely not worth doing?
+
+9. Oldham sits on higher ground than Manchester (some areas are 200m+ above sea level). Does the elevation, wind exposure, or weather pattern make any practical difference to installations or panel performance?
+
+10. A lot of the older terraced stock in Oldham has stone slate roofs rather than modern tiles. Does this affect installation — different fixings, weight considerations, any specialist requirements?
+
+11. Some Oldham properties still have older electrical systems — old fuse boxes, no RCD protection. How often do you encounter this, and what's the typical additional cost for a consumer unit upgrade alongside a solar install?
+
+12. For the larger detached homes in Saddleworth, what size systems are you typically recommending? 6kW? 8kW? More? What kind of savings can these homeowners expect?
+
+### Battery Storage & EV Specific to Oldham
+
+13. For Oldham's terraced houses with lower energy consumption, does a battery still make financial sense, or would you sometimes recommend panels only? What's the threshold where you'd say a battery isn't worth it?
+
+14. Many Oldham terraces have no driveway — just street parking or a rear yard. How does this affect EV charger installations? Do you run cables through to rear yards? What about charging from a front-mounted charger when you park on the street?
+
+15. For commuters from Oldham into Manchester (common route — 20-30 minute drive or Metrolink tram), what kind of daily charging costs would a typical EV use? How does this compare to petrol for the same commute?
+
+### Commercial & Landlord Market
+
+16. Oldham has a significant landlord/buy-to-let market, particularly in central areas. Do landlords enquire about solar? Is there a business case for a landlord to install solar on a rental property, or does it only make sense if they're paying the electricity bill?
+
+17. Oldham town centre still has old mill buildings and commercial/industrial units. Have you done any solar installs on these types of properties? What are the opportunities and challenges?
+
+18. Are there types of commercial businesses in Oldham where solar would be a particularly good fit — takeaways, corner shops, small manufacturing, warehouses?
+
+### Pricing & Competition
+
+19. How does your pricing compare to the competitors active in Oldham? Greentech Renewables in Bury advertise 0% finance — do you offer anything similar, or do you compete on price/quality/service?
+
+20. E-Verve Energy advertises solar in Greater Manchester "from £3,395." Is that realistic for a decent system, or is it a loss-leader / minimal spec quote? What would a typical Renegade installation cost for an Oldham terrace?
+
+21. Trust Renewables position themselves as a social enterprise. Does that angle resonate with customers, or do people ultimately choose on price and reviews?
+
+22. Some competitors offer in-roof (integrated) solar panels. Do you offer these? Are they popular for terraced houses where aesthetics matter?
+
+23. Logic Renewables are based right in the Oldham area (Shaw/Royton). Do you see them as your main local competitor? Any thoughts on how to differentiate?
+
+### Grants, Schemes & Local Knowledge
+
+24. Oldham Council has active ECO4 and Local Authority Flex schemes offering grants for energy improvements. Have any of your customers used these? How does the process work — does the homeowner apply separately, or can you help facilitate?
+
+25. Are you aware of the Oldham Green New Deal initiatives — the community solar schemes, the Wrigley Head solar farm, the Energy Futures project? Could any of this be referenced in the content to show alignment with the council's direction?
+
+26. Oldham Community Power has put solar on local schools. Have you ever done any public sector or community installations? Would you be interested in this kind of work?
+
+27. For Oldham properties in conservation areas (parts of Saddleworth, some central Oldham areas), what are the practical limitations for solar? Do you ever recommend standalone battery systems for properties where roof panels aren't possible?
+
+### Content & Marketing
+
+28. What would you say to an Oldham homeowner who's on the fence about solar — maybe they think Manchester doesn't get enough sun, or that their terraced house is too small?
+
+29. Is there anything specific about Oldham properties or the local area that you'd want highlighted on the website — something that national companies wouldn't know or bother mentioning?
+
+30. If a customer in Chadderton or Royton calls you, how quickly could you typically get out there for a survey? Same day? Next day? Within the week?
+
+31. Do you have any existing Oldham-area customers who might provide testimonials or case studies we could use (with their permission)?
+
+32. Are there any particular panel brands or battery systems you'd recommend specifically for Oldham's terraced houses — maybe something compact or particularly efficient for limited roof space?
+
+33. For Saddleworth specifically — these are often premium properties with higher energy bills. Would you pitch the service differently here compared to, say, a 2-bed terrace in central Oldham?
+
+34. The Metrolink tram runs through Oldham (Shaw, Derker, Oldham Mumps, Oldham King Street, Freehold, South Chadderton, Hollinwood). Is there any angle around EV chargers and public transport — e.g., people who drive to a tram stop and park?
+
+35. What's the single strongest reason someone in Oldham should choose Renegade over a competitor who's already based in the area?
+
+---
+
+## 6. SEO & Keyword Targets
+
+### Primary Keywords (per page)
+- "solar panel installer Oldham"
+- "solar panels Oldham"
+- "EV charger installation Oldham"
+- "EICR Oldham"
+- "commercial solar Oldham"
+- "battery storage Oldham"
+
+### Long-tail Keywords
+- "solar panels terraced house Oldham"
+- "solar panel installer Chadderton"
+- "solar panels Saddleworth"
+- "solar panels Royton"
+- "solar panel installer Shaw"
+- "EV charger terraced house Oldham"
+- "EICR Victorian terrace Oldham"
+- "commercial solar Oldham industrial unit"
+- "solar panel grants Oldham"
+- "ECO4 solar Oldham"
+- "MCS certified solar installer Oldham"
+
+### Content Hooks
+- Oldham's Green New Deal / Climate Emergency declaration
+- ECO4 grants for older properties
+- Terraced house solar expertise
+- Saddleworth premium property market
+- Commuter savings (Oldham to Manchester)
+- 0% VAT until 2027
+- Smart Export Guarantee earnings


### PR DESCRIPTION
## Summary
Added comprehensive market research and strategic planning document for expanding Renegade Solar's service area into Oldham, Greater Manchester.

## Changes
- **New file**: `OLDHAM-MARKET-RESEARCH.md` — A detailed 420-line market analysis and expansion guide covering:
  - Market opportunity assessment (proximity, housing stock, council backing, available grants)
  - Competitive landscape analysis (8+ local competitors with strengths/weaknesses)
  - Renegade's competitive advantages and key messaging points
  - Proposed new pages for Oldham and neighbourhood-specific content
  - Technical research findings on east-west roofs, stone slate installations, consumer unit upgrades, battery viability, and conservation areas
  - 24 strategic questions for Ashley to provide local expertise and real-world experience
  - SEO keyword targets and content hooks

## Key Details
- Identifies Oldham as a high-potential market: 96,000 households, 48.8% terraced housing (Renegade's core strength), strong council green energy backing, and only 13 minutes from Prestwich
- Provides detailed competitive analysis of 8+ active installers in the area
- Outlines proposed content structure: 1 location root page + 4 service-location pages, with Phase 2 neighbourhood pages for Chadderton, Royton, Shaw, Lees, and Saddleworth
- Separates research into two parts: Part A (factual/technical findings for Ashley to verify) and Part B (strategic questions only Ashley can answer based on local experience)
- Includes specific data on property types, pricing, energy savings, grant eligibility, and commuter economics relevant to Oldham

This document serves as the foundation for the Oldham expansion strategy and will guide content creation and market positioning.

https://claude.ai/code/session_012AS4bdn4ajMsGxffRow5SE