### PR TITLE
Add comprehensive linkbuilding strategy for Renegade Solar

### DIFF
--- a/LINKBUILDING-PLAN.md
+++ b/LINKBUILDING-PLAN.md
@@ -1,222 +1,224 @@
-# Renegade Solar — Linkbuilding Plan
+# Renegade Solar — Linkbuilding Plan (Month 1-2)
 
-## Company Overview
+## Company
 
-- **Trading name:** Renegade Solar (legal entity: Renegade Electrical Ltd, company #11368812)
+- **Trading name:** Renegade Solar (Renegade Electrical Ltd, #11368812)
 - **Location:** Prestwich, North Manchester
 - **Owner:** Ashley Merritt
 - **Website:** renegade-solar.co.uk
 - **Services:** Solar PV, battery storage, EV chargers, EICR inspections
-- **Coverage:** Greater Manchester and the wider North West UK
+- **Coverage:** Greater Manchester and the wider North West
 
 ---
 
-## Part 1: Current Online Presence (Audit)
+## Current State
 
-### Where Renegade Solar currently has listings/links
+Renegade has listings on the core industry/accreditation platforms but is missing
+from most of the high-DA general directories where competitors appear.
 
-| Source | URL / Status | Quality | Action Needed |
-|--------|-------------|---------|---------------|
-| **Own website** | renegade-solar.co.uk | Good — well-built, lots of local landing pages | Maintain |
-| **Checkatrade** | checkatrade.com/trades/renegadeelectrical | Strong — 100 reviews, 9.86/10 | Maintain, keep requesting reviews |
-| **TrustMark** | trustmark.org.uk/firms/Renegade%20Electrical%20Ltd-3127838-M24%202SY | Listed with correct details | Check link back to website is present |
-| **NAPIT** | search.napit.org.uk/member/66870/renegade-electrical-ltd | Listed but no contact details shown | **Update listing** — add phone, website, email |
-| **HIES Consumer Code** | search.hiesscheme.org.uk (member R302-047) | Listed | Verify link to website is present |
-| **MCS Certified** | mcscertified.com/find-an-installer | Should appear in search results | Verify listing appears correctly with website link |
-| **Companies House** | find-and-update.company-information.service.gov.uk/company/11368812 | Auto-generated, no website link | N/A — informational only |
-| **Instagram** | @renegadeelectrical (221 followers, 35 posts) | Low activity | **Post more consistently**, link in bio to website |
-| **LinkedIn** | linkedin.com/company/renegade-solar | Exists but sparse | **Flesh out company page** — description, services, posts |
-| **Facebook** | @RenSolarManchester | Not found in search results | **Verify page exists and is public**, optimise with full details |
-| **YouTube** | Channel exists (from website code) | Not found in search results | **Start posting installation videos/timelapse content** |
-| **Google Business Profile** | Not confirmed in search results | **CRITICAL GAP** | **Create or claim and fully optimise** |
-| **SolarReviews.com** | solarreviews.com/installers/renegade-solar-reviews | Profile exists but **zero reviews** | **Ask customers to leave reviews here** |
+### What we already have
 
-### Summary of current state
+| Source | Status | Notes |
+|--------|--------|-------|
+| **Checkatrade** (DA ~90) | 100 reviews, 9.86/10 | Best asset. Keep requesting reviews. |
+| **TrustMark** (gov-backed) | Listed, correct details | Verify website link is present and clickable. |
+| **NAPIT** (industry body) | Listed but **no contact details shown** | Needs fixing — see Week 1. |
+| **HIES Consumer Code** | Member R302-047 | Verify website link is present. |
+| **MCS Certified** | NAP-66870 | Verify listing in their public installer search includes website link. |
+| **Instagram** | @renegadeelectrical | Low activity. Bio should link to website. |
+| **LinkedIn** | Company page exists | Sparse — needs fleshing out. |
+| **Facebook** | @RenSolarManchester | May not be publicly visible — needs checking. |
 
-Renegade Solar has a solid foundation with Checkatrade, TrustMark, NAPIT, HIES, and MCS — the core accreditation bodies. But there are significant gaps in general business directories, review platforms, and social profiles. Most critically, there appears to be **no active Google Business Profile**, which is the single most impactful local SEO asset.
+### What's missing (the gaps that matter)
 
----
+| Gap | Impact |
+|-----|--------|
+| **Google Business Profile** | Critical. This is the single biggest local SEO factor. Without it, Renegade is invisible in Maps and local pack results. |
+| **Trustpilot** (DA ~93) | Competitor P4 Solar has 219 five-star reviews here. Renegade has no profile. |
+| **Which? Trusted Traders** (DA ~90) | Multiple direct competitors listed (Solarus, Atlantic Renewables, Connect Electric). Dofollow link + strong trust signal. |
+| **Yell.com** (DA ~70) | Basic but high-DA UK directory. Free listing. No reason not to be here. |
+| **Houzz** (DA ~90+) | Strong DA, good for photo-heavy trades. Free pro profile. |
+| **Nextdoor** (DA ~60+) | Hyper-local. Atlantic Renewables is already on here. |
+| **Bark.com** (DA ~55) | Free profile. Solarus Energy listed here. |
 
-## Part 2: Quick Wins — Fix and Improve Existing Mentions
+### What we're deliberately skipping
 
-These are things that can be done immediately at zero cost:
-
-### Priority 1 (Do this week)
-
-1. **Google Business Profile** — Claim or create the listing for "Renegade Solar" at the Prestwich address. Add:
-   - All services (Solar PV, Battery Storage, EV Chargers, EICR)
-   - Photos of completed installations
-   - Business hours
-   - Link to renegade-solar.co.uk
-   - Request reviews from past customers (aim for 20+ to start)
-
-2. **NAPIT listing** — Log in and add full contact details (phone, email, website URL). Currently shows no contact information.
-
-3. **SolarReviews.com** — The profile exists with zero reviews. Email past happy customers a direct link to leave a review. Even 5-10 reviews here would put Renegade ahead of most local competitors on this platform.
-
-4. **LinkedIn company page** — Add a proper company description, services list, location, and start sharing installation photos/case studies. Ashley should link his personal profile as Director.
-
-### Priority 2 (Do within a month)
-
-5. **Facebook page** — Ensure it's publicly visible, has the correct business category (Solar Energy Company), complete contact info, website link, and regular posts.
-
-6. **Instagram** — Increase posting frequency. Installation timelapse videos, before/after shots, and customer testimonial clips perform well. Use local hashtags (#ManchesterSolar #NorthWestSolar #PrestwichBusiness etc.)
-
-7. **YouTube** — Start uploading installation videos, even short ones filmed on a phone. "Day in the life of a solar installer" and educational content ("How many panels does a Manchester terrace need?") can attract local traffic.
+| Site | Why |
+|------|-----|
+| **SolarReviews.com** | US-only site. The "Renegade Solar" profile there is a different company in Utah. Zero value. |
+| **Renewable Energy Hub** (renewableenergyhub.co.uk) | Thin site, only 8 Trustpilot reviews in 10+ years, likely low DA. Not worth the effort. |
+| **Solar Panels Network** (solarpanelsnetwork.com) | Generic, no evidence of real traffic or authority. Skip. |
+| **Renewables Excellence** (renewablesexcellence.co.uk) | Launched mid-2025, will have negligible DA. Maybe revisit in a year. |
+| **local-quotes.co.uk** | Low authority, unlikely to move the needle. |
+| **MyHouseProject** (myhouseproject.co.uk) | Thin directory site. Skip. |
+| **FreeIndex** | Low DA, spammy feel. Not worth it. |
+| **YouTube / video content** | Ashley is too busy to produce videos right now. Revisit later if capacity changes. |
+| **Guest posting on solar blogs** | Time-intensive. Better ROI from directory listings and accreditations first. Revisit in month 3+. |
+| **Paid directories** (TrustATrader, MyBuilder, RatedPeople) | Pay-to-play lead gen platforms. May be worth it for leads, but that's a separate decision from linkbuilding. |
 
 ---
 
-## Part 3: New Directory Listings (Where Competitors Are, Renegade Isn't)
+## Month 1 Plan
 
-The following directories list Manchester-area solar competitors but **do not currently list Renegade Solar**:
+The goal: fix what we already have, then claim the free high-DA listings.
 
-### Free directories
+### Week 1: Fix existing listings
 
-| Directory | Competitors Listed | Action |
-|-----------|-------------------|--------|
-| **Which? Trusted Traders** (trustedtraders.which.co.uk) | Atlantic Renewables, Solarus Energy, Connect Electric, Spectra Solar, TJS Solar | **Apply for membership** — requires vetting process |
-| **Bark.com** (bark.com) | Solarus Energy, Trust Renewables, Manchester Renewables | **Create free profile** |
-| **Renewable Energy Hub** (renewableenergyhub.co.uk) | Atlantic Renewables, Firehawk, Blue Solar, Cactus Energy | **Submit listing** — free for MCS installers |
-| **CompareMySolar** (comparemysolar.co.uk) | Atlantic Renewables | **Submit listing** |
-| **Solar Panels Network** (solarpanelsnetwork.com) | Various Manchester installers | **Submit listing** |
-| **Houzz** (houzz.com) | Shawton Energy, Ecogen | **Create professional profile** with photos |
-| **local-quotes.co.uk** | 98+ Manchester installers | **Submit listing** |
-| **Renewables Excellence** (renewablesexcellence.co.uk) | Manchester Renewables, Solarus, Greentech Renewables | **Submit listing** |
-| **Yell.com** | Not found for any "renegade" listing | **Create free listing** |
-| **FreeIndex** (freeindex.co.uk) | Various local trades | **Create free listing** |
-| **192.com Business Directory** | Solarus Energy listed | **Submit listing** |
-| **Nextdoor** (nextdoor.co.uk) | Atlantic Renewables | **Claim business page** — strong for hyper-local visibility |
-| **MyHouseProject** (myhouseproject.co.uk) | Atlantic Renewables | **Submit listing** |
-| **Trustpilot** (trustpilot.com) | P4 Solar (219 reviews, 5 stars) | **Claim free profile**, start requesting reviews |
+These are quick, free, and just require logging in to existing accounts.
 
-### Paid/application directories
+| # | Task | Time | Detail |
+|---|------|------|--------|
+| 1 | **Fix NAPIT listing** | 15 min | Log in at napit.org.uk, add phone (07868 643 147), email, and website URL. Currently shows nothing. |
+| 2 | **Check TrustMark listing** | 10 min | Verify the website field links to renegade-solar.co.uk and is clickable. TrustMark currently shows the address as Middleton, Rochdale — confirm this is correct or update. |
+| 3 | **Check HIES listing** | 10 min | Search for member R302-047 at hiesscheme.org.uk. Verify website link is present. |
+| 4 | **Check MCS listing** | 10 min | Search the MCS installer database for NAP-66870. Verify website link is present and correct. |
+| 5 | **Verify Octopus Energy partner link** | 10 min | Check whether octopus.energy or any Octopus partner page links back to renegade-solar.co.uk. If not, contact them — Ashley is an Octopus Trusted Partner, there should be a listing. |
+| 6 | **Instagram bio** | 5 min | Make sure bio links to renegade-solar.co.uk (not a linktree or similar). |
+| 7 | **LinkedIn company page** | 30 min | Add proper description, service list, Prestwich location, website URL. Link Ashley's personal profile as Director/Founder. |
 
-| Directory | Notes | Action |
-|-----------|-------|--------|
-| **Checkatrade** | Already listed | Maintain |
-| **TrustATrader** (trustatrader.com) | Lists Manchester solar installers | **Investigate membership** |
-| **MyBuilder** (mybuilder.com) | Popular UK trades platform | **Investigate membership** |
-| **RatedPeople** (ratedpeople.com) | Lead generation + directory | **Investigate membership** |
+### Week 2: Google Business Profile
 
-### Greater Manchester green/net-zero directories
+This is the single most important action in the entire plan.
 
-| Directory | Notes | Action |
-|-----------|-------|--------|
-| **Green Economy Marketplace** (greeneconomy.co.uk) | Website mentions Renegade is listed, but no external evidence found | **Verify listing is live and complete** |
-| **Bee Net Zero / beenetzero.co.uk** | GM net-zero business support hub with installer directory | **Get listed on the marketplace** |
-| **GM Green City** (gmgreencity.com/find-a-solar-installer) | Directory for school solar scheme installers | **Apply to be listed** |
-| **NW Route to Net Zero** (nwroutetonetzero.com) | Features GM green energy case studies | **Pitch a case study** |
-| **Energy Innovation Agency directory** (via Greener Greater Manchester) | Uni of Manchester / MMU / Salford collaboration | **Apply for listing** |
+| # | Task | Time | Detail |
+|---|------|------|--------|
+| 8 | **Create or claim Google Business Profile** | 30-60 min | Go to business.google.com. Search for the business. If it exists, claim it. If not, create it. |
+| 9 | **Fully optimise the profile** | 1 hr | Add: business name ("Renegade Solar"), primary category ("Solar Energy Company"), secondary categories ("Electrician", "Battery Storage"), all services, business hours, phone, website, service area (Greater Manchester postcodes). Upload 10+ photos of completed installations. Write a proper business description. |
+| 10 | **Request Google reviews** | ongoing | Text/email 10-20 past customers the direct Google review link. Aim for 20+ reviews in the first month. A personal message from Ashley works better than a generic email. Checkatrade proves customers are happy — they just need to say it on Google too. |
 
----
+### Weeks 3-4: High-DA free directory listings
 
-## Part 4: Competitor Gap Analysis
+One listing per day. Each takes 10-20 minutes. Use **consistent NAP** everywhere:
 
-### What competitors do that Renegade doesn't (yet)
+> **Renegade Solar**
+> Prestwich, Manchester
+> 07868 643 147
+> renegade-solar.co.uk
 
-| Competitor | What they have | Renegade equivalent |
-|------------|---------------|---------------------|
-| **Solarus Energy** | Which? Trusted Trader status, 192.com listing, CHAS Elite, BREEAM, OZEV, RECC accreditations, Bark profile | Missing most of these |
-| **Atlantic Renewables** | Which? Trusted Trader, CompareMySolar listing, Nextdoor page, Renewable Energy Hub listing, MyHouseProject listing | Missing all of these |
-| **P4 Solar** | 219 Trustpilot reviews (5 stars), tree planting pledge (PR angle) | No Trustpilot, no PR angle |
-| **Perfect Sense Energy** | Publishes "Top 10" listicle content that other sites reference | No content marketing |
-| **Connect Electric (Bury)** | Which? Trusted Trader, based in nearby Whitefield | Direct local competitor — need to match their directory presence |
-
-### Key accreditation gaps to investigate
-
-- **Which? Trusted Trader** — Multiple competitors have this. Strong trust signal and generates a high-DA backlink.
-- **RECC (Renewable Energy Consumer Code)** — Alternative to HIES, some installers hold both.
-- **OZEV (Office for Zero Emission Vehicles)** — If doing EV charger installs, this accreditation generates a backlink from gov.uk-adjacent sources.
-- **CHAS (Contractors Health and Safety Assessment Scheme)** — Useful for commercial work and generates a directory listing.
+| # | Directory | Est. DA | Cost | Notes |
+|---|-----------|---------|------|-------|
+| 11 | **Trustpilot** | ~93 | Free | Claim the business profile at business.trustpilot.com. Once live, start requesting reviews from customers. Even 10-15 reviews puts Renegade on the map here. |
+| 12 | **Yell.com** | ~70 | Free | Create a basic free listing. Don't bother with their paid upgrades. |
+| 13 | **Bark.com** | ~55 | Free | Create a pro profile. Competitor Solarus Energy is here. Bark also generates leads, which is a bonus. |
+| 14 | **Nextdoor** | ~60 | Free | Claim business page. Hyper-local — residents in Prestwich, Whitefield, Bury, etc. see recommendations from neighbours. Atlantic Renewables is already listed. |
+| 15 | **Houzz** | ~90+ | Free | Create a professional profile. Upload installation photos. Houzz is photo-driven, which works well for before/after solar installs. High DA for a free listing. |
+| 16 | **192.com** | ~55 | Free | Submit a basic business listing. Competitor Solarus Energy is listed here. |
+| 17 | **CompareMySolar** | ~40 | Free | Submit installer profile. This is a Dutch-run comparison tool but has UK presence. Atlantic Renewables is here. Lower priority than the others but still free and quick. |
 
 ---
 
-## Part 5: Content & PR Link Opportunities
+## Month 2 Plan
 
-### Guest posts / contributed content
+The goal: pursue the high-value listings that require applications/vetting, and
+start building the review base across platforms.
 
-| Target | Approach |
-|--------|----------|
-| **Feedspot's top UK solar blogs** (solarblogger.net, Naked Solar, Viridian Solar, Project Solar UK) | Pitch practical guest posts: "What Manchester homeowners need to know about solar on terraced houses", "Battery storage in the North West — is it worth it?" |
-| **MoneySavingExpert forums** | Become an active, helpful contributor in solar threads. Don't spam — answer questions honestly and mention Renegade naturally when relevant. |
-| **Manchester-focused blogs and news** | Pitch to local outlets: Manchester Evening News, About Manchester, Confidentials, I Love MCR. Angle: local business story, energy cost savings, green Manchester. |
-| **Loom Solar "Write for Us"** | Submit a guest post (they accept solar industry content and allow backlinks) |
+### Which? Trusted Traders (the big one)
 
-### Case study / PR angles
+| # | Task | Time | Detail |
+|---|------|------|--------|
+| 18 | **Apply for Which? Trusted Traders** | 1-2 hrs | This is the highest-value directory listing available to a business like Renegade. Which? has ~DA 90, the "Endorsed by Which?" badge is a genuine trust signal, and multiple Manchester competitors already have it (Solarus, Atlantic Renewables, Connect Electric, Spectra Solar, TJS Solar). The listing includes a dofollow link, customer reviews, photo gallery, and "Endorsed" badge. Application involves a vetting/assessment process. Start it early in month 2. |
 
-| Angle | Detail |
-|-------|--------|
-| **"Local sparky turned solar entrepreneur"** | Ashley's personal story — 15+ years as an electrician, worked on Terminal 2, now helping Manchester go green. Human interest piece for local press. |
-| **Customer case studies** | Publish detailed case studies on the website (with real kWh data, bill savings, photos). These become linkable assets that directories, blogs, and forums can reference. |
-| **School/community projects** | If Renegade has done or could do a school or community building, pitch it to GM Green City and local press. |
-| **"Manchester terrace solar" niche** | Create the definitive guide to solar panels on Manchester terraces — roof angles, sizes, planning, shading from neighbours. This is genuinely useful content that could attract natural links. |
+### Accreditations that generate links
 
-### Local link building
+These aren't just directory listings — they're genuine accreditations that create
+trust signals AND backlinks.
 
-| Source | Approach |
-|--------|----------|
-| **Prestwich & Whitefield business groups** | Join local business networks (Prestwich Village Community, Bury Business Club, etc.) — these often have member directories online |
-| **Greater Manchester Chamber of Commerce** | Membership includes a directory listing with backlink |
-| **Federation of Small Businesses (FSB)** | Member directory with backlink |
-| **Supplier partnerships** | DMEGC, Trina, Solax, AlphaESS — ask to be listed as an approved installer on their UK websites |
-| **Octopus Energy partner page** | Already a Trusted Partner — verify there's a link from Octopus's website to Renegade |
+| # | Accreditation | What it does | Detail |
+|---|---------------|-------------|--------|
+| 19 | **OZEV (Office for Zero Emission Vehicles)** | gov.uk-adjacent listing as approved EV charger installer | If Renegade does OZEV-approved EV charger installs, this should be straightforward. Generates a listing on a high-authority government-adjacent domain. |
+| 20 | **CHAS (Contractors Health and Safety)** | H&S accreditation with directory listing | Useful for winning commercial solar work AND generates a backlink. Competitor Solarus Energy has CHAS Elite. |
+| 21 | **RECC (Renewable Energy Consumer Code)** | Consumer protection scheme with member directory | Alternative/complement to HIES. Some installers hold both. Worth investigating if the additional consumer protection badge helps win customers. |
 
----
+### Green Manchester directories
 
-## Part 6: Prioritised Action Plan
+| # | Directory | Detail |
+|---|-----------|--------|
+| 22 | **Bee Net Zero / Green Economy Marketplace** | The website claims Renegade is already a Green Economy member. Verify this is actually live at greeneconomy.co.uk. If not, apply. Bee Net Zero is a GM Combined Authority initiative with decent institutional backing. |
+| 23 | **GM Green City** | If there's a solar installer directory on gmgreencity.com, apply to be listed. This is council-backed so will have decent authority. |
 
-### Tier 1 — Do immediately (biggest impact, least effort)
+### Supplier partnerships
 
-1. Claim/create **Google Business Profile** and request 20+ reviews
-2. Update **NAPIT listing** with full contact details
-3. Claim **Trustpilot** profile
-4. Create profiles on **Bark.com**, **Yell.com**, **FreeIndex**
-5. Submit to **Renewable Energy Hub**, **CompareMySolar**, **Solar Panels Network**
+| # | Supplier | Detail |
+|---|----------|--------|
+| 24 | **DMEGC** | Ashley installs DMEGC panels and the website has a page about it. Ask DMEGC if they have an "approved installers" or "where to buy" page on their UK/EU website. If yes, get Renegade listed. |
+| 25 | **Solax** | Same approach — check if Solax has an installer finder on their website. |
+| 26 | **AlphaESS** | Same approach. |
+| 27 | **Trina Solar** | Same approach — Renegade rates the Trina Vertex series. |
 
-### Tier 2 — Do within 1-2 months
+### Reviews (ongoing through month 2)
 
-6. Apply for **Which? Trusted Trader** status
-7. Register on **Nextdoor**, **Houzz**, **local-quotes.co.uk**, **Renewables Excellence**, **192.com**, **MyHouseProject**
-8. Verify and complete **Green Economy Marketplace** listing
-9. Apply to **Bee Net Zero** marketplace and **GM Green City** directory
-10. Flesh out **LinkedIn company page** and increase **Instagram/Facebook** activity
-11. Verify **Octopus Energy** links back to the website
-12. Contact **DMEGC/Trina/Solax** about approved installer listings
-
-### Tier 3 — Ongoing (1-3 months and beyond)
-
-13. Publish **3-5 customer case studies** on the website (with real data)
-14. Write the **"Manchester Terrace Solar Guide"** as a linkable asset
-15. Pitch **local press** with Ashley's story (MEN, About Manchester, I Love MCR)
-16. Start **guest posting** on solar blogs (Naked Solar, Solar Blogger, etc.)
-17. Join **Prestwich/Bury business networks** for local directory links
-18. Consider **Greater Manchester Chamber of Commerce** and **FSB** membership
-19. Investigate **OZEV**, **CHAS**, and **RECC** accreditations
-20. Build a **YouTube presence** with installation videos
+| # | Platform | Target | Detail |
+|---|----------|--------|--------|
+| 28 | **Google** | 20+ reviews | Keep requesting. This is the most impactful review platform. |
+| 29 | **Trustpilot** | 10+ reviews | Send the direct review link to happy customers. |
+| 30 | **Checkatrade** | Maintain flow | Already strong at 100 reviews. Keep it ticking over with 2-3 per month. |
 
 ---
 
-## Part 7: Tracking
+## What Good Looks Like (End of Month 2)
 
-Keep a simple spreadsheet tracking:
+If Ashley works through this list, by the end of month 2 the link profile
+should look like:
 
-| Column | Purpose |
-|--------|---------|
-| **Source** | Directory/site name |
-| **URL** | Link to our listing |
-| **Status** | Applied / Listed / Rejected |
-| **Link type** | Dofollow / Nofollow / Unlinked mention |
-| **DA (approx)** | Domain authority of linking site |
-| **Date submitted** | When we applied |
-| **Date live** | When the link went live |
-| **Notes** | Login details, contact person, renewal dates |
+**Industry/accreditation links (high trust):**
+- MCS (verified, with website link) ✓
+- NAPIT (with full contact details) ✓
+- TrustMark (with website link) ✓
+- HIES (with website link) ✓
+- Which? Trusted Traders (application in progress or approved)
+- OZEV (if applicable)
+- CHAS (application in progress or approved)
+
+**High-DA directory links:**
+- Google Business Profile (with 20+ reviews)
+- Checkatrade (existing, 100+ reviews)
+- Trustpilot (new, building reviews)
+- Yell.com
+- Houzz
+- Nextdoor
+- Bark.com
+- 192.com
+- CompareMySolar
+
+**Supplier/partner links:**
+- Octopus Energy (verified)
+- DMEGC / Solax / AlphaESS / Trina (where available)
+- Green Economy Marketplace (verified)
+
+**Social profiles (with backlinks):**
+- LinkedIn (complete)
+- Instagram (bio link)
+- Facebook (verified public)
+
+That's roughly 20+ quality backlinks from a mix of high-DA directories,
+industry bodies, and local/green platforms — all achievable within 2 months
+without producing any content or video, and without paying for any dodgy
+directory listings.
 
 ---
 
-## Notes
+## Consistent NAP (use everywhere)
 
-- This plan focuses on realistic, achievable link building for a small local business. We're not competing with national brands for high-DA editorial links — we're building a comprehensive, consistent local link profile that search engines trust.
-- The most impactful single action is getting a properly optimised Google Business Profile with reviews. This alone will improve local search visibility significantly.
-- Quality over quantity. A link from Which? Trusted Traders or Green Economy is worth more than 50 spam directory submissions.
-- Every listing should use consistent NAP (Name, Address, Phone) details across all platforms. Inconsistency confuses search engines.
-- Review velocity matters. A steady flow of 2-3 new reviews per month across Google, Checkatrade, and Trustpilot is more valuable than a one-off burst.
+> **Business name:** Renegade Solar
+> **Address:** Prestwich, Manchester (use full address where required)
+> **Phone:** 07868 643 147
+> **Website:** https://www.renegade-solar.co.uk
+> **Email:** renegadeelectrical99@gmail.com
+
+Use this exact format everywhere. NAP consistency across listings is a
+direct local SEO ranking factor. Don't use "Renegade Electrical" on some
+and "Renegade Solar" on others unless the platform specifically requires the
+registered company name.
+
+---
+
+## What to revisit later (month 3+)
+
+These are worth doing eventually but don't belong in the first two months:
+
+- **Content marketing:** Publish case studies on the website, write a "Manchester terrace solar guide." These become linkable assets but require time to create.
+- **Local press:** Pitch Ashley's story to Manchester Evening News, I Love MCR, etc. Good angle but needs a hook (community project, milestone, etc.)
+- **Guest posting:** Contribute to solar industry blogs. Time-intensive; do it when the directory foundation is solid.
+- **Video content:** YouTube, Instagram Reels, TikTok. When Ashley has capacity. Installation timelapses are gold but take time to film and edit.
+- **Business networks:** GM Chamber of Commerce, FSB, Prestwich business groups — membership with directory listings. Worth it but not urgent.
+- **MoneySavingExpert forums:** Build presence as a helpful contributor in solar threads. Long game.

--- a/LINKBUILDING-PLAN.md
+++ b/LINKBUILDING-PLAN.md
@@ -1,0 +1,222 @@
+# Renegade Solar — Linkbuilding Plan
+
+## Company Overview
+
+- **Trading name:** Renegade Solar (legal entity: Renegade Electrical Ltd, company #11368812)
+- **Location:** Prestwich, North Manchester
+- **Owner:** Ashley Merritt
+- **Website:** renegade-solar.co.uk
+- **Services:** Solar PV, battery storage, EV chargers, EICR inspections
+- **Coverage:** Greater Manchester and the wider North West UK
+
+---
+
+## Part 1: Current Online Presence (Audit)
+
+### Where Renegade Solar currently has listings/links
+
+| Source | URL / Status | Quality | Action Needed |
+|--------|-------------|---------|---------------|
+| **Own website** | renegade-solar.co.uk | Good — well-built, lots of local landing pages | Maintain |
+| **Checkatrade** | checkatrade.com/trades/renegadeelectrical | Strong — 100 reviews, 9.86/10 | Maintain, keep requesting reviews |
+| **TrustMark** | trustmark.org.uk/firms/Renegade%20Electrical%20Ltd-3127838-M24%202SY | Listed with correct details | Check link back to website is present |
+| **NAPIT** | search.napit.org.uk/member/66870/renegade-electrical-ltd | Listed but no contact details shown | **Update listing** — add phone, website, email |
+| **HIES Consumer Code** | search.hiesscheme.org.uk (member R302-047) | Listed | Verify link to website is present |
+| **MCS Certified** | mcscertified.com/find-an-installer | Should appear in search results | Verify listing appears correctly with website link |
+| **Companies House** | find-and-update.company-information.service.gov.uk/company/11368812 | Auto-generated, no website link | N/A — informational only |
+| **Instagram** | @renegadeelectrical (221 followers, 35 posts) | Low activity | **Post more consistently**, link in bio to website |
+| **LinkedIn** | linkedin.com/company/renegade-solar | Exists but sparse | **Flesh out company page** — description, services, posts |
+| **Facebook** | @RenSolarManchester | Not found in search results | **Verify page exists and is public**, optimise with full details |
+| **YouTube** | Channel exists (from website code) | Not found in search results | **Start posting installation videos/timelapse content** |
+| **Google Business Profile** | Not confirmed in search results | **CRITICAL GAP** | **Create or claim and fully optimise** |
+| **SolarReviews.com** | solarreviews.com/installers/renegade-solar-reviews | Profile exists but **zero reviews** | **Ask customers to leave reviews here** |
+
+### Summary of current state
+
+Renegade Solar has a solid foundation with Checkatrade, TrustMark, NAPIT, HIES, and MCS — the core accreditation bodies. But there are significant gaps in general business directories, review platforms, and social profiles. Most critically, there appears to be **no active Google Business Profile**, which is the single most impactful local SEO asset.
+
+---
+
+## Part 2: Quick Wins — Fix and Improve Existing Mentions
+
+These are things that can be done immediately at zero cost:
+
+### Priority 1 (Do this week)
+
+1. **Google Business Profile** — Claim or create the listing for "Renegade Solar" at the Prestwich address. Add:
+   - All services (Solar PV, Battery Storage, EV Chargers, EICR)
+   - Photos of completed installations
+   - Business hours
+   - Link to renegade-solar.co.uk
+   - Request reviews from past customers (aim for 20+ to start)
+
+2. **NAPIT listing** — Log in and add full contact details (phone, email, website URL). Currently shows no contact information.
+
+3. **SolarReviews.com** — The profile exists with zero reviews. Email past happy customers a direct link to leave a review. Even 5-10 reviews here would put Renegade ahead of most local competitors on this platform.
+
+4. **LinkedIn company page** — Add a proper company description, services list, location, and start sharing installation photos/case studies. Ashley should link his personal profile as Director.
+
+### Priority 2 (Do within a month)
+
+5. **Facebook page** — Ensure it's publicly visible, has the correct business category (Solar Energy Company), complete contact info, website link, and regular posts.
+
+6. **Instagram** — Increase posting frequency. Installation timelapse videos, before/after shots, and customer testimonial clips perform well. Use local hashtags (#ManchesterSolar #NorthWestSolar #PrestwichBusiness etc.)
+
+7. **YouTube** — Start uploading installation videos, even short ones filmed on a phone. "Day in the life of a solar installer" and educational content ("How many panels does a Manchester terrace need?") can attract local traffic.
+
+---
+
+## Part 3: New Directory Listings (Where Competitors Are, Renegade Isn't)
+
+The following directories list Manchester-area solar competitors but **do not currently list Renegade Solar**:
+
+### Free directories
+
+| Directory | Competitors Listed | Action |
+|-----------|-------------------|--------|
+| **Which? Trusted Traders** (trustedtraders.which.co.uk) | Atlantic Renewables, Solarus Energy, Connect Electric, Spectra Solar, TJS Solar | **Apply for membership** — requires vetting process |
+| **Bark.com** (bark.com) | Solarus Energy, Trust Renewables, Manchester Renewables | **Create free profile** |
+| **Renewable Energy Hub** (renewableenergyhub.co.uk) | Atlantic Renewables, Firehawk, Blue Solar, Cactus Energy | **Submit listing** — free for MCS installers |
+| **CompareMySolar** (comparemysolar.co.uk) | Atlantic Renewables | **Submit listing** |
+| **Solar Panels Network** (solarpanelsnetwork.com) | Various Manchester installers | **Submit listing** |
+| **Houzz** (houzz.com) | Shawton Energy, Ecogen | **Create professional profile** with photos |
+| **local-quotes.co.uk** | 98+ Manchester installers | **Submit listing** |
+| **Renewables Excellence** (renewablesexcellence.co.uk) | Manchester Renewables, Solarus, Greentech Renewables | **Submit listing** |
+| **Yell.com** | Not found for any "renegade" listing | **Create free listing** |
+| **FreeIndex** (freeindex.co.uk) | Various local trades | **Create free listing** |
+| **192.com Business Directory** | Solarus Energy listed | **Submit listing** |
+| **Nextdoor** (nextdoor.co.uk) | Atlantic Renewables | **Claim business page** — strong for hyper-local visibility |
+| **MyHouseProject** (myhouseproject.co.uk) | Atlantic Renewables | **Submit listing** |
+| **Trustpilot** (trustpilot.com) | P4 Solar (219 reviews, 5 stars) | **Claim free profile**, start requesting reviews |
+
+### Paid/application directories
+
+| Directory | Notes | Action |
+|-----------|-------|--------|
+| **Checkatrade** | Already listed | Maintain |
+| **TrustATrader** (trustatrader.com) | Lists Manchester solar installers | **Investigate membership** |
+| **MyBuilder** (mybuilder.com) | Popular UK trades platform | **Investigate membership** |
+| **RatedPeople** (ratedpeople.com) | Lead generation + directory | **Investigate membership** |
+
+### Greater Manchester green/net-zero directories
+
+| Directory | Notes | Action |
+|-----------|-------|--------|
+| **Green Economy Marketplace** (greeneconomy.co.uk) | Website mentions Renegade is listed, but no external evidence found | **Verify listing is live and complete** |
+| **Bee Net Zero / beenetzero.co.uk** | GM net-zero business support hub with installer directory | **Get listed on the marketplace** |
+| **GM Green City** (gmgreencity.com/find-a-solar-installer) | Directory for school solar scheme installers | **Apply to be listed** |
+| **NW Route to Net Zero** (nwroutetonetzero.com) | Features GM green energy case studies | **Pitch a case study** |
+| **Energy Innovation Agency directory** (via Greener Greater Manchester) | Uni of Manchester / MMU / Salford collaboration | **Apply for listing** |
+
+---
+
+## Part 4: Competitor Gap Analysis
+
+### What competitors do that Renegade doesn't (yet)
+
+| Competitor | What they have | Renegade equivalent |
+|------------|---------------|---------------------|
+| **Solarus Energy** | Which? Trusted Trader status, 192.com listing, CHAS Elite, BREEAM, OZEV, RECC accreditations, Bark profile | Missing most of these |
+| **Atlantic Renewables** | Which? Trusted Trader, CompareMySolar listing, Nextdoor page, Renewable Energy Hub listing, MyHouseProject listing | Missing all of these |
+| **P4 Solar** | 219 Trustpilot reviews (5 stars), tree planting pledge (PR angle) | No Trustpilot, no PR angle |
+| **Perfect Sense Energy** | Publishes "Top 10" listicle content that other sites reference | No content marketing |
+| **Connect Electric (Bury)** | Which? Trusted Trader, based in nearby Whitefield | Direct local competitor — need to match their directory presence |
+
+### Key accreditation gaps to investigate
+
+- **Which? Trusted Trader** — Multiple competitors have this. Strong trust signal and generates a high-DA backlink.
+- **RECC (Renewable Energy Consumer Code)** — Alternative to HIES, some installers hold both.
+- **OZEV (Office for Zero Emission Vehicles)** — If doing EV charger installs, this accreditation generates a backlink from gov.uk-adjacent sources.
+- **CHAS (Contractors Health and Safety Assessment Scheme)** — Useful for commercial work and generates a directory listing.
+
+---
+
+## Part 5: Content & PR Link Opportunities
+
+### Guest posts / contributed content
+
+| Target | Approach |
+|--------|----------|
+| **Feedspot's top UK solar blogs** (solarblogger.net, Naked Solar, Viridian Solar, Project Solar UK) | Pitch practical guest posts: "What Manchester homeowners need to know about solar on terraced houses", "Battery storage in the North West — is it worth it?" |
+| **MoneySavingExpert forums** | Become an active, helpful contributor in solar threads. Don't spam — answer questions honestly and mention Renegade naturally when relevant. |
+| **Manchester-focused blogs and news** | Pitch to local outlets: Manchester Evening News, About Manchester, Confidentials, I Love MCR. Angle: local business story, energy cost savings, green Manchester. |
+| **Loom Solar "Write for Us"** | Submit a guest post (they accept solar industry content and allow backlinks) |
+
+### Case study / PR angles
+
+| Angle | Detail |
+|-------|--------|
+| **"Local sparky turned solar entrepreneur"** | Ashley's personal story — 15+ years as an electrician, worked on Terminal 2, now helping Manchester go green. Human interest piece for local press. |
+| **Customer case studies** | Publish detailed case studies on the website (with real kWh data, bill savings, photos). These become linkable assets that directories, blogs, and forums can reference. |
+| **School/community projects** | If Renegade has done or could do a school or community building, pitch it to GM Green City and local press. |
+| **"Manchester terrace solar" niche** | Create the definitive guide to solar panels on Manchester terraces — roof angles, sizes, planning, shading from neighbours. This is genuinely useful content that could attract natural links. |
+
+### Local link building
+
+| Source | Approach |
+|--------|----------|
+| **Prestwich & Whitefield business groups** | Join local business networks (Prestwich Village Community, Bury Business Club, etc.) — these often have member directories online |
+| **Greater Manchester Chamber of Commerce** | Membership includes a directory listing with backlink |
+| **Federation of Small Businesses (FSB)** | Member directory with backlink |
+| **Supplier partnerships** | DMEGC, Trina, Solax, AlphaESS — ask to be listed as an approved installer on their UK websites |
+| **Octopus Energy partner page** | Already a Trusted Partner — verify there's a link from Octopus's website to Renegade |
+
+---
+
+## Part 6: Prioritised Action Plan
+
+### Tier 1 — Do immediately (biggest impact, least effort)
+
+1. Claim/create **Google Business Profile** and request 20+ reviews
+2. Update **NAPIT listing** with full contact details
+3. Claim **Trustpilot** profile
+4. Create profiles on **Bark.com**, **Yell.com**, **FreeIndex**
+5. Submit to **Renewable Energy Hub**, **CompareMySolar**, **Solar Panels Network**
+
+### Tier 2 — Do within 1-2 months
+
+6. Apply for **Which? Trusted Trader** status
+7. Register on **Nextdoor**, **Houzz**, **local-quotes.co.uk**, **Renewables Excellence**, **192.com**, **MyHouseProject**
+8. Verify and complete **Green Economy Marketplace** listing
+9. Apply to **Bee Net Zero** marketplace and **GM Green City** directory
+10. Flesh out **LinkedIn company page** and increase **Instagram/Facebook** activity
+11. Verify **Octopus Energy** links back to the website
+12. Contact **DMEGC/Trina/Solax** about approved installer listings
+
+### Tier 3 — Ongoing (1-3 months and beyond)
+
+13. Publish **3-5 customer case studies** on the website (with real data)
+14. Write the **"Manchester Terrace Solar Guide"** as a linkable asset
+15. Pitch **local press** with Ashley's story (MEN, About Manchester, I Love MCR)
+16. Start **guest posting** on solar blogs (Naked Solar, Solar Blogger, etc.)
+17. Join **Prestwich/Bury business networks** for local directory links
+18. Consider **Greater Manchester Chamber of Commerce** and **FSB** membership
+19. Investigate **OZEV**, **CHAS**, and **RECC** accreditations
+20. Build a **YouTube presence** with installation videos
+
+---
+
+## Part 7: Tracking
+
+Keep a simple spreadsheet tracking:
+
+| Column | Purpose |
+|--------|---------|
+| **Source** | Directory/site name |
+| **URL** | Link to our listing |
+| **Status** | Applied / Listed / Rejected |
+| **Link type** | Dofollow / Nofollow / Unlinked mention |
+| **DA (approx)** | Domain authority of linking site |
+| **Date submitted** | When we applied |
+| **Date live** | When the link went live |
+| **Notes** | Login details, contact person, renewal dates |
+
+---
+
+## Notes
+
+- This plan focuses on realistic, achievable link building for a small local business. We're not competing with national brands for high-DA editorial links — we're building a comprehensive, consistent local link profile that search engines trust.
+- The most impactful single action is getting a properly optimised Google Business Profile with reviews. This alone will improve local search visibility significantly.
+- Quality over quantity. A link from Which? Trusted Traders or Green Economy is worth more than 50 spam directory submissions.
+- Every listing should use consistent NAP (Name, Address, Phone) details across all platforms. Inconsistency confuses search engines.
+- Review velocity matters. A steady flow of 2-3 new reviews per month across Google, Checkatrade, and Trustpilot is more valuable than a one-off burst.


### PR DESCRIPTION
## Summary
Added a detailed linkbuilding and SEO strategy document for Renegade Solar, outlining current online presence, quick wins, directory opportunities, and a prioritised action plan for improving search visibility and local authority.

## Key Changes
- **Current state audit**: Documented existing listings across accreditation bodies (Checkatrade, TrustMark, NAPIT, HIES, MCS), social platforms, and review sites, identifying critical gaps (notably missing Google Business Profile)
- **Quick wins**: Prioritised zero-cost improvements to existing mentions (NAPIT contact details, SolarReviews reviews, LinkedIn optimisation)
- **Directory gap analysis**: Identified 20+ free and paid directories where competitors are listed but Renegade Solar is not (Bark, Renewable Energy Hub, CompareMySolar, Trustpilot, Which? Trusted Traders, etc.)
- **Competitor benchmarking**: Analysed what local competitors (Solarus Energy, Atlantic Renewables, P4 Solar) have that Renegade lacks, including accreditations and directory presence
- **Content & PR opportunities**: Outlined guest posting targets, case study angles, and local link-building approaches
- **Actionable roadmap**: Structured 20-point plan across three tiers (immediate, 1-2 months, ongoing) with tracking methodology

## Notable Details
- Emphasises quality over quantity, focusing on high-authority local links (Which? Trusted Traders, Green Economy Marketplace) rather than spam submissions
- Highlights Google Business Profile as the single highest-impact action
- Includes specific competitor names and their directory presence for direct comparison
- Provides consistent NAP (Name, Address, Phone) guidance to avoid search engine confusion
- Suggests accreditation gaps to investigate (OZEV, CHAS, RECC) that could generate additional backlinks

https://claude.ai/code/session_018wkkohTvDLJLo6FsYfamp2