### PR TITLE
Fix WhatsApp contact link URL format

### DIFF
--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -14,7 +14,7 @@ Drop us a message and we'll get back to you as soon as we can.
 
 - **Email:** [renegadeelectrical99@gmail.com](mailto:renegadeelectrical99@gmail.com)
 - **Phone:** [07868 643 147](tel:07868643147)
-- **WhatsApp:** [Click here](https://wa.us/447868643147)
+- **WhatsApp:** [Click here](https://wa.me/447868643147)
 - **Facebook:** [@RenSolarManchester](https://www.facebook.com/RenSolarManchester)
 
 - **Company Registration Number:** [11368812](https://find-and-update.company-information.service.gov.uk/company/11368812)


### PR DESCRIPTION
## Summary
Updated the WhatsApp contact link to use the correct URL format for WhatsApp Web integration.

## Changes
- Changed WhatsApp URL from `https://wa.us/447868643147` to `https://wa.me/447868643147`
  - `wa.me` is the official WhatsApp Web URL scheme
  - `wa.us` is not a valid WhatsApp domain and may not function correctly

## Details
The `wa.me` domain is the standard, officially supported WhatsApp link format that properly redirects users to WhatsApp Web or the mobile app. This ensures the contact link works reliably across all devices and browsers.

https://claude.ai/code/session_01RXrkYhrTkxP3hoNpSzZ6wK