### PR TITLE
Update HIES Consumer Code reference number

### DIFF
--- a/src/accreditations/hies-consumer-code.md
+++ b/src/accreditations/hies-consumer-code.md
@@ -2,7 +2,7 @@
 title: HIES Consumer Code
 logo: /assets/accreditation-logos/hies-consumer-code.png
 tooltip: A consumer protection organisation covering the installation of home energy products
-url: https://search.hiesscheme.org.uk/renegade-electrical-ltd-R302-047
+url: https://search.hiesscheme.org.uk/renegade-electrical-ltd-R399-800
 snippet: HIES Consumer Code membership provides homeowners with comprehensive consumer protection throughout the solar panel installation process.
 ---
 
@@ -37,4 +37,4 @@ As a North Manchester-based team with over 15 years of experience, we understand
 
 If you're considering solar panels for your home, [contact us](/contact/) to discuss your options. We can provide clear information about the process, costs, and benefits of switching to solar energy.
 
-[Renegade Solar - HEIS Consumer Code member serving Prestwich and North Manchester](https://search.hiesscheme.org.uk/renegade-electrical-ltd-R302-047)
+[Renegade Solar - HEIS Consumer Code member serving Prestwich and North Manchester](https://search.hiesscheme.org.uk/renegade-electrical-ltd-R399-800)

--- a/src/pages/documents.md
+++ b/src/pages/documents.md
@@ -53,7 +53,7 @@ TrustMark is the UK Government's only endorsed quality scheme for tradespeople w
 
 The Home Energy Installation Systems (HIES) Consumer Code provides comprehensive consumer protection throughout the solar panel installation process.
 
-[Verify on HIES Website](https://search.hiesscheme.org.uk/renegade-electrical-ltd-R302-047) | [Learn More](/accreditations/hies-consumer-code/)
+[Verify on HIES Website](https://search.hiesscheme.org.uk/renegade-electrical-ltd-R399-800) | [Learn More](/accreditations/hies-consumer-code/)
 
 ## Checkatrade Member
 


### PR DESCRIPTION
## Summary
Updated the HIES Consumer Code reference number across documentation pages to reflect the current accreditation identifier.

## Changes Made
- Updated HIES Consumer Code URL from `R302-047` to `R399-800` in the accreditation page
- Updated the same reference number in the verification link on the documents page
- Both the direct URL and inline link text have been synchronized with the new reference number

## Details
The HIES (Home Energy Installation Systems) Consumer Code reference number for Renegade Electrical Ltd has been updated from `R302-047` to `R399-800`. This change ensures that all links to the HIES scheme verification page point to the correct, current accreditation record across the website.

https://claude.ai/code/session_019ZM5bHTGDvgUfTHiU4DCKF