### PR TITLE
Add Trustpilot review links across site

### DIFF
--- a/src/_data/socials.json
+++ b/src/_data/socials.json
@@ -18,5 +18,9 @@
   "google": {
     "text": "Check out Renegade Solar on Google Maps",
     "url": "https://maps.app.goo.gl/8j3vvkz4uCafyRPN7"
+  },
+  "trustpilot": {
+    "text": "Review Renegade Solar on Trustpilot",
+    "url": "https://uk.trustpilot.com/review/renegade-solar.co.uk"
   }
 }

--- a/src/_includes/homepage-reviews.html
+++ b/src/_includes/homepage-reviews.html
@@ -17,6 +17,9 @@
       <a href="https://www.checkatrade.com/trades/renegadeelectrical" target="_blank" class="btn secondary-btn">
         View on Checkatrade
       </a>
+      <a href="https://uk.trustpilot.com/review/renegade-solar.co.uk" target="_blank" class="btn secondary-btn">
+        Review Us on Trustpilot
+      </a>
     </div>
   </div>
 </section>

--- a/src/_layouts/reviews.html
+++ b/src/_layouts/reviews.html
@@ -28,6 +28,13 @@ layout: base.html
         >
           View on Checkatrade
         </a>
+        <a
+          href="https://uk.trustpilot.com/review/renegade-solar.co.uk"
+          target="_blank"
+          class="btn secondary-btn"
+        >
+          Review Us on Trustpilot
+        </a>
       </div>
 
       <hr />
@@ -41,6 +48,13 @@ layout: base.html
           class="btn primary-btn"
         >
           View on Checkatrade
+        </a>
+        <a
+          href="https://uk.trustpilot.com/review/renegade-solar.co.uk"
+          target="_blank"
+          class="btn secondary-btn"
+        >
+          Review Us on Trustpilot
         </a>
       </div>
     </div>

--- a/src/assets/icons/trustpilot.svg
+++ b/src/assets/icons/trustpilot.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>


### PR DESCRIPTION
## Summary
This PR adds Trustpilot review integration to the website, allowing customers to easily leave reviews on the Trustpilot platform alongside existing Checkatrade links.

## Key Changes
- Added Trustpilot review button to the reviews layout page (appears in two review sections)
- Added Trustpilot review button to the homepage reviews section
- Added Trustpilot entry to the socials data file for centralized URL management
- Added Trustpilot SVG icon asset for consistent branding

## Implementation Details
- Trustpilot links point to `https://uk.trustpilot.com/review/renegade-solar.co.uk`
- Buttons use the existing `secondary-btn` class for consistent styling with Checkatrade buttons
- Links open in new tabs (`target="_blank"`)
- Trustpilot data added to `socials.json` for potential reuse in other templates
- SVG icon follows the same style as other social icons (24x24, stroke-based design)

https://claude.ai/code/session_01HLApGPFzwSrB92JxYBYMMX