### PR TITLE
Update Trustpilot URLs from uk subdomain to www

### DIFF
--- a/src/_data/socials.json
+++ b/src/_data/socials.json
@@ -21,6 +21,6 @@
   },
   "trustpilot": {
     "text": "Review Renegade Solar on Trustpilot",
-    "url": "https://uk.trustpilot.com/review/renegade-solar.co.uk"
+    "url": "https://www.trustpilot.com/review/renegade-solar.co.uk"
   }
 }

--- a/src/_includes/homepage-reviews.html
+++ b/src/_includes/homepage-reviews.html
@@ -17,7 +17,7 @@
       <a href="https://www.checkatrade.com/trades/renegadeelectrical" target="_blank" class="btn secondary-btn">
         View on Checkatrade
       </a>
-      <a href="https://uk.trustpilot.com/review/renegade-solar.co.uk" target="_blank" class="btn secondary-btn">
+      <a href="https://www.trustpilot.com/review/renegade-solar.co.uk" target="_blank" class="btn secondary-btn">
         Review Us on Trustpilot
       </a>
     </div>

--- a/src/_layouts/reviews.html
+++ b/src/_layouts/reviews.html
@@ -29,7 +29,7 @@ layout: base.html
           View on Checkatrade
         </a>
         <a
-          href="https://uk.trustpilot.com/review/renegade-solar.co.uk"
+          href="https://www.trustpilot.com/review/renegade-solar.co.uk"
           target="_blank"
           class="btn secondary-btn"
         >
@@ -50,7 +50,7 @@ layout: base.html
           View on Checkatrade
         </a>
         <a
-          href="https://uk.trustpilot.com/review/renegade-solar.co.uk"
+          href="https://www.trustpilot.com/review/renegade-solar.co.uk"
           target="_blank"
           class="btn secondary-btn"
         >

--- a/src/pages/reviews.md
+++ b/src/pages/reviews.md
@@ -11,4 +11,4 @@ noindex: false
 We take pride in our exceptional service and the satisfaction of our customers.
 Below you'll find all the reviews from our satisfied customers who have chosen us for solar panel installations, battery systems, and various electrical services.
 
-Our team is committed to delivering high-quality workmanship and excellent customer service on every project. We're grateful for the wonderful feedback from our clients, and we're proud to maintain our high rating on Checkatrade.
+Our team is committed to delivering high-quality workmanship and excellent customer service on every project. We're grateful for the wonderful feedback from our clients, and we're proud to maintain our high rating on Checkatrade. You can also find us on [Trustpilot](https://www.trustpilot.com/review/renegade-solar.co.uk).


### PR DESCRIPTION
## Summary
Updated all Trustpilot review links across the site to use the standard `www.trustpilot.com` domain instead of the `uk.trustpilot.com` subdomain.

## Changes Made
- Updated Trustpilot URLs in `src/_layouts/reviews.html` (2 instances)
- Updated Trustpilot URL in `src/_data/socials.json`
- Updated Trustpilot URL in `src/_includes/homepage-reviews.html`
- Added Trustpilot link to reviews page content in `src/pages/reviews.md`

## Details
All instances of `https://uk.trustpilot.com/review/renegade-solar.co.uk` have been changed to `https://www.trustpilot.com/review/renegade-solar.co.uk`. Additionally, the reviews page now includes a reference to the Trustpilot profile in the main content with a clickable link.

https://claude.ai/code/session_015EFExhn3cCQbm4AKftLequ