### PR TITLE
Remove em-dashes and AI writing patterns from content pages

### DIFF
--- a/src/locations/chadderton.md
+++ b/src/locations/chadderton.md
@@ -12,4 +12,4 @@ tags: location
 
 Renegade Solar provides professional solar panel installations and electrical services throughout Chadderton. With easy M60 access and close proximity to [Failsworth](/services/solar-and-battery-installations/failsworth/) where we already work, Chadderton's mix of terraced and semi-detached properties offers strong solar potential.
 
-We're based in Prestwich, just a short drive away, and understand Chadderton's housing stock — from traditional terraces to family semis averaging around £215k. Ashley personally surveys and installs every system, so you get honest advice from the electrician who's actually doing the work.
+We're based in Prestwich, just a short drive away, and understand Chadderton's housing stock - from traditional terraces to family semis averaging around £215k. Ashley personally surveys and installs every system, so you get honest advice from the electrician who's actually doing the work.

--- a/src/locations/lees.md
+++ b/src/locations/lees.md
@@ -12,4 +12,4 @@ tags: location
 
 Renegade Solar provides professional solar panel installations and electrical services in Lees. Sitting between central [Oldham](/oldham/) and [Saddleworth](/saddleworth/), Lees has a mix of terraced and semi-detached homes with good solar potential.
 
-We're based in Prestwich, serving the whole Oldham borough with MCS-certified installations. Ashley personally handles every survey and installation — no salespeople, just honest advice from a qualified electrician about what'll work for your property.
+We're based in Prestwich, serving the whole Oldham borough with MCS-certified installations. Ashley personally handles every survey and installation - no salespeople, just honest advice from a qualified electrician about what'll work for your property.

--- a/src/locations/oldham.md
+++ b/src/locations/oldham.md
@@ -12,4 +12,4 @@ tags: location
 
 Based just 13 minutes away in Prestwich, we serve homeowners and businesses across the Oldham borough with professional solar panel installations, battery storage, EV chargers, commercial solar, and electrical services. We already work in [Failsworth](/services/solar-and-battery-installations/failsworth/) and cover the whole borough including [Chadderton](/chadderton/), [Royton](/royton/), [Shaw](/shaw/), [Lees](/lees/), and [Saddleworth](/saddleworth/).
 
-Oldham's housing stock is dominated by terraced houses — nearly half of all properties in the borough. These are exactly the kind of installations we handle day in, day out. Whether you're in a two-bed terrace in Coldhurst or a detached stone-built home in Uppermill, we'll give you honest advice about what'll work for your property and what won't.
+Oldham's housing stock is dominated by terraced houses - nearly half of all properties in the borough. These are exactly the kind of installations we handle day in, day out. Whether you're in a two-bed terrace in Coldhurst or a detached stone-built home in Uppermill, we'll give you honest advice about what'll work for your property and what won't.

--- a/src/locations/royton.md
+++ b/src/locations/royton.md
@@ -10,6 +10,6 @@ tags: location
 
 # Royton
 
-Renegade Solar delivers expert solar panel installations and electrical services throughout Royton. With property prices seeing 41.5% growth over five years, homeowners here are investing in their properties — and solar is one of the smartest investments you can make, adding around 4% to your property value while cutting energy bills.
+Renegade Solar delivers expert solar panel installations and electrical services throughout Royton. With property prices seeing 41.5% growth over five years, homeowners here are investing in their properties - and solar is one of the smartest investments you can make, adding around 4% to your property value while cutting energy bills.
 
-Royton's mix of terraces and semis provides good roof options for solar. We're based nearby in Prestwich and handle everything personally — from initial survey through to installation and grid connection paperwork.
+Royton's mix of terraces and semis provides good roof options for solar. We're based nearby in Prestwich and handle everything personally - from initial survey through to installation and grid connection paperwork.

--- a/src/locations/saddleworth.md
+++ b/src/locations/saddleworth.md
@@ -1,6 +1,6 @@
 ---
 title: Solar Installations in Saddleworth | Renegade Solar
-description: MCS-certified solar panel and battery installations in Saddleworth — Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw. Expert advice on stone-built properties and conservation areas.
+description: MCS-certified solar panel and battery installations in Saddleworth - Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw. Expert advice on stone-built properties and conservation areas.
 link_title: Saddleworth
 heading: Solar Installations in Saddleworth
 layout: location-root.html
@@ -10,6 +10,6 @@ tags: location
 
 # Saddleworth
 
-Renegade Solar provides professional solar panel installations and electrical services across Saddleworth's villages — Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw. With larger detached and semi-detached homes, higher energy consumption, and more roof space, Saddleworth properties are excellent candidates for solar.
+Renegade Solar provides professional solar panel installations and electrical services across Saddleworth's villages - Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw. With larger detached and semi-detached homes, higher energy consumption, and more roof space, Saddleworth properties are excellent candidates for solar.
 
-As the most expensive area in the [Oldham](/oldham/) borough (average property price around £393k), Saddleworth homeowners are well-positioned to invest in solar and battery systems that deliver significant savings. We understand the specific challenges here — stone slate roofs, conservation areas, and exposed hilltop locations — and we'll give you honest advice about what works and what doesn't.
+As the most expensive area in the [Oldham](/oldham/) borough (average property price around £393k), Saddleworth homeowners are well-positioned to invest in solar and battery systems that deliver significant savings. We understand the specific challenges here - stone slate roofs, conservation areas, and exposed hilltop locations - and we'll give you honest advice about what works and what doesn't.

--- a/src/pages/ev-charger-relocation-manchester.md
+++ b/src/pages/ev-charger-relocation-manchester.md
@@ -20,7 +20,7 @@ This isn't a service most installers actively offer. Ashley does, by name, in wr
 
 ## Why same-installer-both-ends matters
 
-It's not just convenient. It's better technically:
+There are technical advantages too:
 
 - **The disconnection is documented properly.** Ashley provides electrical certification for the work he's done at the old property - clean record for the buyer of your old house and for any future property sale.
 - **He already knows the kit.** When he arrives at the new property he isn't reverse-engineering somebody else's wiring.

--- a/src/services/commercial-solar-installations/chadderton.md
+++ b/src/services/commercial-solar-installations/chadderton.md
@@ -10,17 +10,17 @@ gallery_tags: [commercial]
 
 # Commercial Solar for Chadderton Businesses
 
-Chadderton's M60 corridor has commercial and industrial units with exactly the right profile for solar — big flat roofs, high daytime electricity consumption, and bills that keep climbing. We're based nearby in [Prestwich](/services/commercial-solar-installations/prestwich/) and serve Chadderton businesses with [MCS-certified](/accreditations/mcs-certified/) commercial solar installations.
+Chadderton's M60 corridor has commercial and industrial units with exactly the right profile for solar - big flat roofs, high daytime electricity consumption, and bills that keep climbing. We're based nearby in [Prestwich](/services/commercial-solar-installations/prestwich/) and serve Chadderton businesses with [MCS-certified](/accreditations/mcs-certified/) commercial solar installations.
 
-The key advantage of commercial solar over domestic is timing — businesses use electricity during the day when panels are generating. You consume nearly every unit your panels produce, which means payback of typically 3-4 years, then 20+ years of dramatically reduced costs.
+The key advantage of commercial solar over domestic is timing - businesses use electricity during the day when panels are generating. You consume nearly every unit your panels produce, which means payback of typically 3-4 years, then 20+ years of dramatically reduced costs.
 
 ## Where the returns are strongest
 
-The industrial estates and commercial units along Broadgate and the M60 corridor are ideal candidates. Warehouses, workshops, and light manufacturing units with flat roofs give us maximum flexibility — we mount panels at the optimal angle regardless of building orientation.
+The industrial estates and commercial units along Broadgate and the M60 corridor are ideal candidates. Warehouses, workshops, and light manufacturing units with flat roofs give us maximum flexibility - we mount panels at the optimal angle regardless of building orientation.
 
-Retail units, restaurants, and takeaways running commercial kitchens and equipment all day see strong alignment between generation and consumption. Cold storage and refrigeration businesses spend heavily on electricity round the clock — solar covers the daytime load and cuts the overall bill significantly.
+Retail units, restaurants, and takeaways running commercial kitchens and equipment all day see strong alignment between generation and consumption. Cold storage and refrigeration businesses spend heavily on electricity round the clock - solar covers the daytime load and cuts the overall bill significantly.
 
-## Staff EV charging — a free employee benefit
+## Staff EV charging - a free employee benefit
 
 If you have parking space, combining commercial solar with [EV charging points](/services/electric-vehicle-charger-installations/chadderton/) for staff vehicles creates a genuine perk at zero ongoing electricity cost. Panels generate, chargers use the power, employees save money. It costs you nothing after the initial installation.
 

--- a/src/services/commercial-solar-installations/lees.md
+++ b/src/services/commercial-solar-installations/lees.md
@@ -10,16 +10,16 @@ gallery_tags: [commercial]
 
 # Commercial Solar for Lees Businesses
 
-Lees businesses spending heavily on electricity can slash those costs with commercial solar. Businesses consume electricity during the day when panels generate — you use nearly every unit directly, which means payback of typically 3-4 years and decades of reduced costs after that.
+Lees businesses spending heavily on electricity can slash those costs with commercial solar. Businesses consume electricity during the day when panels generate - you use nearly every unit directly, which means payback of typically 3-4 years and decades of reduced costs after that.
 
 ## Local businesses that benefit
 
-Shops, workshops, and commercial units along the High Street and up towards Lees Road are candidates for solar if you own the building and have decent roof space. Hospitality businesses — cafes, restaurants, takeaways — see particularly good returns because kitchen equipment and refrigeration run all day, perfectly aligned with solar generation.
+Shops, workshops, and commercial units along the High Street and up towards Lees Road are candidates for solar if you own the building and have decent roof space. Hospitality businesses - cafes, restaurants, takeaways - see particularly good returns because kitchen equipment and refrigeration run all day, perfectly aligned with solar generation.
 
 If you've got a flat roof, we can angle panels for optimal generation regardless of building orientation. Spare land or parking areas can supplement rooftop systems or power [EV charging](/services/electric-vehicle-charger-installations/lees/) for staff.
 
 ## Our approach
 
-We're based in [Prestwich](/services/commercial-solar-installations/prestwich/), serving the whole [Oldham](/oldham/) borough with [MCS-certified](/accreditations/mcs-certified/) installations. We assess your property and consumption, design a system with detailed financial projections, and handle all grid connections and certifications. You must own the building. If the numbers don't work, we'll tell you — no point in a system that doesn't pay for itself.
+We're based in [Prestwich](/services/commercial-solar-installations/prestwich/), serving the whole [Oldham](/oldham/) borough with [MCS-certified](/accreditations/mcs-certified/) installations. We assess your property and consumption, design a system with detailed financial projections, and handle all grid connections and certifications. You must own the building. If the numbers don't work, we'll tell you - no point in a system that doesn't pay for itself.
 
 **[Contact us today](/contact/) for a free commercial solar consultation.**

--- a/src/services/commercial-solar-installations/oldham.md
+++ b/src/services/commercial-solar-installations/oldham.md
@@ -1,6 +1,6 @@
 ---
 title: Commercial Solar Installations in Oldham | Renegade Solar
-description: Commercial solar for Oldham businesses. Cut electricity costs 70-100% with 3-4 year payback. Factories, warehouses, retail — MCS-certified installer based 13 minutes away.
+description: Commercial solar for Oldham businesses. Cut electricity costs 70-100% with 3-4 year payback. Factories, warehouses, retail - MCS-certified installer based 13 minutes away.
 link_title: Commercial Solar Installations
 heading: Commercial Solar Installations in Oldham
 icon: /assets/icons/commercial-solar.svg
@@ -10,27 +10,27 @@ gallery_tags: [commercial]
 
 # Commercial Solar for Oldham Businesses
 
-Oldham's industrial heritage means plenty of factories, warehouses, and commercial units with big roofs and high electricity bills — perfect candidates for commercial solar. We're based nearby in [Prestwich](/services/commercial-solar-installations/prestwich/), just 13 minutes away, and serve Oldham businesses with [MCS-certified](/accreditations/mcs-certified/) installations that deliver genuine savings.
+Oldham's industrial heritage means plenty of factories, warehouses, and commercial units with big roofs and high electricity bills - perfect candidates for commercial solar. We're based nearby in [Prestwich](/services/commercial-solar-installations/prestwich/), just 13 minutes away, and serve Oldham businesses with [MCS-certified](/accreditations/mcs-certified/) installations that deliver genuine savings.
 
 Commercial properties benefit more from solar than domestic ones because businesses use electricity during the day when generation peaks. You're consuming nearly every kilowatt-hour your panels produce, which shortens payback periods to typically 3-4 years.
 
 ## Oldham businesses that see the best returns
 
-**Factories and manufacturing** — Oldham still has numerous industrial units running heavy machinery. High electricity consumption means faster payback. A business spending £1,000+ monthly on electricity can see transformative savings.
+**Factories and manufacturing** - Oldham still has numerous industrial units running heavy machinery. High electricity consumption means faster payback. A business spending £1,000+ monthly on electricity can see transformative savings.
 
-**Warehouses and distribution** — Large flat roofs are ideal for solar. The M60 corridor through Hollinwood and Chadderton has plenty of commercial properties with excellent roof space.
+**Warehouses and distribution** - Large flat roofs are ideal for solar. The M60 corridor through Hollinwood and Chadderton has plenty of commercial properties with excellent roof space.
 
-**Retail and hospitality** — Shops, restaurants, takeaways running fryers and commercial kitchens all day see strong returns. Daytime consumption aligns perfectly with solar generation.
+**Retail and hospitality** - Shops, restaurants, takeaways running fryers and commercial kitchens all day see strong returns. Daytime consumption aligns perfectly with solar generation.
 
-**Cold storage** — Any business running refrigeration or freezers continuously is spending heavily on electricity and will see rapid payback.
+**Cold storage** - Any business running refrigeration or freezers continuously is spending heavily on electricity and will see rapid payback.
 
-**Old mill buildings** — Oldham's converted mills often have large, unobstructed roof areas. Whether the roof is flat or pitched, we can design systems that work with the building's characteristics.
+**Old mill buildings** - Oldham's converted mills often have large, unobstructed roof areas. Whether the roof is flat or pitched, we can design systems that work with the building's characteristics.
 
 ## Flat and pitched roofs both work
 
-Flat roofs give us flexibility — we mount panels at the optimal angle regardless of building orientation. Pitched roofs on factories, warehouses, and larger commercial buildings offer excellent potential too. We provide multiple design options with detailed financial analysis for each approach.
+Flat roofs give us flexibility - we mount panels at the optimal angle regardless of building orientation. Pitched roofs on factories, warehouses, and larger commercial buildings offer excellent potential too. We provide multiple design options with detailed financial analysis for each approach.
 
-If you have spare land or parking areas, ground-mounted solar supplements rooftop installations or powers [EV charging points](/services/electric-vehicle-charger-installations/oldham/) for staff vehicles — a valuable employee benefit at zero ongoing electricity cost.
+If you have spare land or parking areas, ground-mounted solar supplements rooftop installations or powers [EV charging points](/services/electric-vehicle-charger-installations/oldham/) for staff vehicles - a valuable employee benefit at zero ongoing electricity cost.
 
 ## Oldham Council supports business sustainability
 

--- a/src/services/commercial-solar-installations/royton.md
+++ b/src/services/commercial-solar-installations/royton.md
@@ -10,18 +10,18 @@ gallery_tags: [commercial]
 
 # Commercial Solar for Royton Businesses
 
-Royton has a mix of small businesses, workshops, and commercial premises that are well-suited to solar. If you're spending hundreds or thousands a month on electricity, commercial solar typically pays for itself in 3-4 years — then it's decades of dramatically reduced costs.
+Royton has a mix of small businesses, workshops, and commercial premises that are well-suited to solar. If you're spending hundreds or thousands a month on electricity, commercial solar typically pays for itself in 3-4 years - then it's decades of dramatically reduced costs.
 
 The reason commercial outperforms domestic is simple: businesses use electricity during the day when panels generate. You consume nearly every unit directly, which means the return on investment is faster and the savings are bigger.
 
 ## Small businesses benefit too
 
-You don't need a warehouse to make commercial solar work. A shop or workshop in Royton with a decent-sized flat or pitched roof and monthly electricity bills over £300-400 can see meaningful returns. We design systems around your actual consumption — from modest setups for small retail units to larger arrays for light industrial premises.
+You don't need a warehouse to make commercial solar work. A shop or workshop in Royton with a decent-sized flat or pitched roof and monthly electricity bills over £300-400 can see meaningful returns. We design systems around your actual consumption - from modest setups for small retail units to larger arrays for light industrial premises.
 
-Flat roofs are particularly useful because we can angle panels optimally regardless of building orientation. Pitched roofs work well too — we provide multiple design options with financial analysis for each.
+Flat roofs are particularly useful because we can angle panels optimally regardless of building orientation. Pitched roofs work well too - we provide multiple design options with financial analysis for each.
 
 ## Our approach
 
-We're based in [Prestwich](/services/commercial-solar-installations/prestwich/), serving the whole [Oldham](/oldham/) area with [MCS-certified](/accreditations/mcs-certified/) installations. We assess your property and electricity usage, design a system with detailed financial projections, and handle all grid connections and certifications. You must own the building. If the numbers don't stack up, we'll say so — no point installing a system that doesn't make financial sense.
+We're based in [Prestwich](/services/commercial-solar-installations/prestwich/), serving the whole [Oldham](/oldham/) area with [MCS-certified](/accreditations/mcs-certified/) installations. We assess your property and electricity usage, design a system with detailed financial projections, and handle all grid connections and certifications. You must own the building. If the numbers don't stack up, we'll say so - no point installing a system that doesn't make financial sense.
 
 **[Contact us today](/contact/) for a free commercial solar consultation.**

--- a/src/services/commercial-solar-installations/saddleworth.md
+++ b/src/services/commercial-solar-installations/saddleworth.md
@@ -1,6 +1,6 @@
 ---
 title: Commercial Solar Installations in Saddleworth | Renegade Solar
-description: Commercial solar for Saddleworth businesses — shops, hospitality, farms. Cut electricity costs 70-100% with 3-4 year payback. MCS-certified installer.
+description: Commercial solar for Saddleworth businesses - shops, hospitality, farms. Cut electricity costs 70-100% with 3-4 year payback. MCS-certified installer.
 link_title: Commercial Solar Installations
 heading: Commercial Solar Installations in Saddleworth
 icon: /assets/icons/commercial-solar.svg
@@ -10,7 +10,7 @@ gallery_tags: [commercial]
 
 # Commercial Solar for Saddleworth Businesses
 
-Saddleworth's village businesses, farms, and rural commercial properties are well-suited to solar. Hospitality businesses in Uppermill and Greenfield running kitchens all day, farms with large outbuildings, and any premises with decent roof space and high electricity consumption — these are the businesses where commercial solar transforms the economics.
+Saddleworth's village businesses, farms, and rural commercial properties are well-suited to solar. Hospitality businesses in Uppermill and Greenfield running kitchens all day, farms with large outbuildings, and any premises with decent roof space and high electricity consumption - these are the businesses where commercial solar transforms the economics.
 
 Payback is typically 3-4 years because commercial properties use electricity during the day when panels generate. After that, it's 20+ years of dramatically reduced costs.
 
@@ -20,11 +20,11 @@ Farm buildings with large corrugated or slate roofs have excellent solar potenti
 
 ## Village businesses
 
-The pubs, restaurants, cafes, and shops in Uppermill, Greenfield, Delph, and Dobcross use electricity throughout the day — kitchens, fridges, lighting, heating. Solar generation aligns perfectly with this consumption pattern.
+The pubs, restaurants, cafes, and shops in Uppermill, Greenfield, Delph, and Dobcross use electricity throughout the day - kitchens, fridges, lighting, heating. Solar generation aligns perfectly with this consumption pattern.
 
 ## Conservation areas
 
-Some Saddleworth businesses operate from buildings in conservation areas. Commercial solar generally falls under permitted development, but we check the specifics for your property and handle any planning requirements. For listed buildings, it's more complex — we'll be upfront about what's possible and what isn't.
+Some Saddleworth businesses operate from buildings in conservation areas. Commercial solar generally falls under permitted development, but we check the specifics for your property and handle any planning requirements. For listed buildings, it's more complex - we'll be upfront about what's possible and what isn't.
 
 ## Our approach
 

--- a/src/services/commercial-solar-installations/shaw.md
+++ b/src/services/commercial-solar-installations/shaw.md
@@ -10,18 +10,18 @@ gallery_tags: [commercial]
 
 # Commercial Solar for Shaw Businesses
 
-Shaw's commercial premises — workshops, retail units, and the businesses along Shaw Road — can cut electricity costs dramatically with solar. If your bill is making you wince every month, a system that pays for itself in 3-4 years and then runs for 20+ years starts to look like a no-brainer.
+Shaw's commercial premises - workshops, retail units, and the businesses along Shaw Road - can cut electricity costs dramatically with solar. If your bill is making you wince every month, a system that pays for itself in 3-4 years and then runs for 20+ years starts to look like a no-brainer.
 
 Commercial properties use electricity during the day when solar generates. You consume nearly every unit directly, which makes the return on investment much faster than domestic installations where homeowners are often out during peak generation hours.
 
 ## Mill town roots, modern opportunities
 
-Shaw's industrial heritage means some businesses operate from converted mill buildings or older commercial premises with large, often flat roof areas. These are excellent candidates for solar — big footprint, plenty of space for panels, and usually high electricity consumption from machinery, lighting, or climate control.
+Shaw's industrial heritage means some businesses operate from converted mill buildings or older commercial premises with large, often flat roof areas. These are excellent candidates for solar - big footprint, plenty of space for panels, and usually high electricity consumption from machinery, lighting, or climate control.
 
 Newer commercial units along the main roads work just as well. Whether flat or pitched roof, we design systems that maximise generation from whatever you've got.
 
 ## Our approach
 
-We're based in [Prestwich](/services/commercial-solar-installations/prestwich/), serving the whole [Oldham](/oldham/) area with [MCS-certified](/accreditations/mcs-certified/) installations. We assess your property and actual electricity consumption, design a system with detailed financial projections, and handle all grid connections and [electrical certifications](/services/electrical-testing/). You must own the building. Honest advice — if the numbers don't work, we'll tell you.
+We're based in [Prestwich](/services/commercial-solar-installations/prestwich/), serving the whole [Oldham](/oldham/) area with [MCS-certified](/accreditations/mcs-certified/) installations. We assess your property and actual electricity consumption, design a system with detailed financial projections, and handle all grid connections and [electrical certifications](/services/electrical-testing/). You must own the building. Honest advice - if the numbers don't work, we'll tell you.
 
 **[Contact us today](/contact/) for a free commercial solar consultation.**

--- a/src/services/electric-vehicle-charger-installations/bolton.md
+++ b/src/services/electric-vehicle-charger-installations/bolton.md
@@ -20,7 +20,7 @@ With Bolton currently having fewer than 80 public charge points, this expansion 
 
 ## EV Solutions for Bolton Properties
 
-Bolton's housing landscape is dominated by terraced and semi-detached properties, which together make up 70% of the town's homes. We provide expert EV charger installations across all Bolton property types, from traditional Victorian terraces in areas like Farnworth and Great Lever to modern developments in Horwich and Lostock.
+Terraced and semi-detached properties make up 70% of Bolton's homes. We install EV chargers on all property types, from Victorian terraces in Farnworth and Great Lever to modern developments in Horwich and Lostock.
 
 For Bolton's many terraced properties where off-street parking may be limited, we can advise on the best charging solutions and work within any planning requirements. The council's focus on high-density residential areas means public charging is expanding, but home charging remains the most convenient and cost-effective option where possible.
 

--- a/src/services/electric-vehicle-charger-installations/bury.md
+++ b/src/services/electric-vehicle-charger-installations/bury.md
@@ -10,7 +10,7 @@ icon: /assets/icons/car.svg
 gallery_tags: [electric-vehicle]
 ---
 
-Expert EV charger installations throughout Bury. We provide professional charging solutions for electric cars with smart technology and seamless integration with renewable energy systems.
+EV charger installations throughout Bury. Smart chargers that integrate with solar and battery systems where you've got them.
 
 ## Bury EV Charging Service
 

--- a/src/services/electric-vehicle-charger-installations/chadderton.md
+++ b/src/services/electric-vehicle-charger-installations/chadderton.md
@@ -10,15 +10,15 @@ gallery_tags: [electric-vehicle]
 
 EV charger installations in Chadderton from a NAPIT-registered electrician. Based nearby in Prestwich, already working in neighbouring [Failsworth](/services/solar-and-battery-installations/failsworth/). Ashley assesses your property and installs your charger personally.
 
-## M60 commuters — stop paying for petrol
+## M60 commuters - stop paying for petrol
 
-Chadderton's biggest selling point is the M60 access. If you're driving to Manchester, Stockport, or anywhere on the motorway network, you're spending roughly £675 a year on petrol for a typical commute. On a home EV charger with an off-peak tariff (9.5p/kWh on Octopus Go), that drops to around £100. And public rapid chargers at 50-80p per kWh? More expensive than petrol — avoid them for daily use.
+Chadderton's biggest selling point is the M60 access. If you're driving to Manchester, Stockport, or anywhere on the motorway network, you're spending roughly £675 a year on petrol for a typical commute. On a home EV charger with an off-peak tariff (9.5p/kWh on Octopus Go), that drops to around £100. And public rapid chargers at 50-80p per kWh? More expensive than petrol - avoid them for daily use.
 
 Pair the charger with [solar panels](/services/solar-and-battery-installations/chadderton/) and your summer commute is free. The panels generate enough surplus during daylight hours to cover a 9-mile each-way commute easily.
 
 ## Terraces without driveways
 
-Plenty of Chadderton's terraces along Broadway and Middleton Road have no off-street parking. We can still install a charger — options include front-mounted units with proper cable management or running armoured cable through to a rear yard. Ashley will look at your specific setup and recommend what makes sense.
+Plenty of Chadderton's terraces along Broadway and Middleton Road have no off-street parking. We can still install a charger - options include front-mounted units with proper cable management or running armoured cable through to a rear yard. Ashley will look at your specific setup and recommend what makes sense.
 
 ## The chargers we fit
 

--- a/src/services/electric-vehicle-charger-installations/lees.md
+++ b/src/services/electric-vehicle-charger-installations/lees.md
@@ -10,15 +10,15 @@ gallery_tags: [electric-vehicle]
 
 EV charger installations in Lees from a NAPIT-registered electrician. Based in Prestwich, covering the whole [Oldham](/oldham/) borough. Ashley personally assesses your property and installs your charger.
 
-## Lees to Manchester — the real costs
+## Lees to Manchester - the real costs
 
-Whether you're driving into Manchester or heading to Oldham town centre, home charging beats every alternative. A year of petrol commuting costs around £675. Home charging on Octopus Go's 9.5p/kWh overnight rate? About £100. And public rapid chargers at 50-80p per kWh are worse than petrol — they only make sense for occasional long trips.
+Whether you're driving into Manchester or heading to Oldham town centre, home charging beats every alternative. A year of petrol commuting costs around £675. Home charging on Octopus Go's 9.5p/kWh overnight rate? About £100. And public rapid chargers at 50-80p per kWh are worse than petrol - they only make sense for occasional long trips.
 
-If you've got [solar panels](/services/solar-and-battery-installations/lees/), summer commuting costs nothing — surplus solar covers a typical daily drive with room to spare.
+If you've got [solar panels](/services/solar-and-battery-installations/lees/), summer commuting costs nothing - surplus solar covers a typical daily drive with room to spare.
 
 ## Properties heading uphill
 
-Lees runs from the valley bottom up towards Springhead and Grasscroft. The lower terraces are typical Oldham housing — some with driveways, some without. For terraces without off-street parking, we run armoured cable to rear yards or install front-mounted chargers with proper cable management.
+Lees runs from the valley bottom up towards Springhead and Grasscroft. The lower terraces are typical Oldham housing - some with driveways, some without. For terraces without off-street parking, we run armoured cable to rear yards or install front-mounted chargers with proper cable management.
 
 The larger properties higher up almost always have driveways or garages, making installation straightforward. Either way, it's a one-day job.
 

--- a/src/services/electric-vehicle-charger-installations/oldham.md
+++ b/src/services/electric-vehicle-charger-installations/oldham.md
@@ -8,11 +8,11 @@ icon: /assets/icons/car.svg
 gallery_tags: [electric-vehicle]
 ---
 
-Expert EV charger installations across the Oldham borough — from Chadderton and Royton to Saddleworth. Based in Prestwich, just 13 minutes away, with no travel charges and no salespeople. Ashley, a qualified electrician, assesses your property and installs your charger personally.
+Expert EV charger installations across the Oldham borough - from Chadderton and Royton to Saddleworth. Based in Prestwich, just 13 minutes away, with no travel charges and no salespeople. Ashley, a qualified electrician, assesses your property and installs your charger personally.
 
-## Home charging vs public charging — the numbers
+## Home charging vs public charging - the numbers
 
-Oldham to Manchester is a typical commute — about 9 miles each way. Here's what that costs annually:
+Oldham to Manchester is a typical commute - about 9 miles each way. Here's what that costs annually:
 
 | Scenario | Annual Cost |
 |---|---|
@@ -22,17 +22,17 @@ Oldham to Manchester is a typical commute — about 9 miles each way. Here's wha
 | EV, home solar | £0 |
 | EV, public rapid charger | ~£900-1,125 |
 
-Public rapid charging is more expensive than petrol. Home charging on an off-peak tariff costs a fraction. And if you've got [solar panels](/services/solar-and-battery-installations/oldham/), your daily commute charge comes free in the summer months — a typical 9-mile commute uses about 4.5 kWh, easily covered by surplus solar from a 4kW system.
+Public rapid charging is more expensive than petrol. Home charging on an off-peak tariff costs a fraction. And if you've got [solar panels](/services/solar-and-battery-installations/oldham/), your daily commute charge comes free in the summer months - a typical 9-mile commute uses about 4.5 kWh, easily covered by surplus solar from a 4kW system.
 
-Smart strategy: export your solar at 15p/kWh during the day and charge your car overnight at 7p/kWh on an EV tariff — you're actually making money on the swap.
+Smart strategy: export your solar at 15p/kWh during the day and charge your car overnight at 7p/kWh on an EV tariff - you're actually making money on the swap.
 
 ## Terraced houses and EV charging
 
-Many Oldham terraces don't have driveways — just street parking or a rear yard. We can work with that. Options include front-mounted chargers with proper cable management, or running armoured cable through to a rear yard where you park. Ashley will assess your specific setup during the survey and recommend the most practical solution.
+Many Oldham terraces don't have driveways - just street parking or a rear yard. We can work with that. Options include front-mounted chargers with proper cable management, or running armoured cable through to a rear yard where you park. Ashley will assess your specific setup during the survey and recommend the most practical solution.
 
 ## Metrolink commuters
 
-Oldham has 10 Metrolink stops through the borough, with park-and-ride at Hollinwood, Oldham Mumps, Derker, and Shaw and Crompton. If you drive to the tram and leave your car all day, home charging is perfect — charge overnight on cheap electricity, drive to the stop, come home to a charged car. No need for expensive public chargers.
+Oldham has 10 Metrolink stops through the borough, with park-and-ride at Hollinwood, Oldham Mumps, Derker, and Shaw and Crompton. If you drive to the tram and leave your car all day, home charging is perfect - charge overnight on cheap electricity, drive to the stop, come home to a charged car. No need for expensive public chargers.
 
 ## The chargers
 
@@ -40,11 +40,11 @@ Got **SolaX** or **AlphaESS** gear already? Their chargers integrate with their 
 
 The smart chargers wait until electricity drops to off-peak rates (9.5p/kWh on Octopus Go) before charging your car. Compare that to 50-80p at a public rapid charger. You plug in when you get home and forget about it.
 
-Already bought a charger? That's fine — we'll fit it.
+Already bought a charger? That's fine - we'll fit it.
 
 ## Quick and tidy installation
 
-Installation takes a day. The charger units are weatherproof so we can mount them wherever suits your parking. Need cable running round from your consumer unit to the other side of the house? No problem — we use heavy-duty armoured cable designed for outdoor runs.
+Installation takes a day. The charger units are weatherproof so we can mount them wherever suits your parking. Need cable running round from your consumer unit to the other side of the house? No problem - we use heavy-duty armoured cable designed for outdoor runs.
 
 Your consumer unit needs to be up to date, but if you've already got [solar panels](/services/solar-and-battery-installations/oldham/) or a [battery](/services/home-battery-installations/) fitted, it'll already be up to scratch. Even without renewable kit, you can sign up for a time-of-use tariff to get cheap overnight charging.
 
@@ -58,4 +58,4 @@ Your consumer unit needs to be up to date, but if you've already got [solar pane
 
 ## Get in touch
 
-**Ready to install your home EV charger? [Contact us](/contact/) for a free consultation and quote.** Ashley will come out to assess your property personally — no call centres, no sales scripts, just honest advice from a qualified electrician.
+**Ready to install your home EV charger? [Contact us](/contact/) for a free consultation and quote.** Ashley will come out to assess your property personally - no call centres, no sales scripts, just honest advice from a qualified electrician.

--- a/src/services/electric-vehicle-charger-installations/royton.md
+++ b/src/services/electric-vehicle-charger-installations/royton.md
@@ -12,22 +12,22 @@ EV charger installations in Royton from a NAPIT-registered electrician. Based in
 
 ## The cost comparison that matters
 
-Royton homeowners are investing in their properties — and an EV charger is one of the better investments. A typical commute to Manchester costs around £675 a year in petrol. On a home charger with Octopus Go's 9.5p/kWh overnight rate, the same commute costs about £100. That's over £500 back in your pocket every year.
+Royton homeowners are investing in their properties - and an EV charger is one of the better investments. A typical commute to Manchester costs around £675 a year in petrol. On a home charger with Octopus Go's 9.5p/kWh overnight rate, the same commute costs about £100. That's over £500 back in your pocket every year.
 
-The worst option? Public rapid chargers at 50-80p per kWh — actually more expensive than filling up with petrol. Home charging is the only approach that makes daily driving affordable.
+The worst option? Public rapid chargers at 50-80p per kWh - actually more expensive than filling up with petrol. Home charging is the only approach that makes daily driving affordable.
 
-## Semis with driveways — straightforward installs
+## Semis with driveways - straightforward installs
 
 Royton has a good proportion of semis with off-street parking, which makes charger installation simple. We mount the unit on an exterior wall near your parking spot, run cable from your consumer unit, and you're charging by the end of the day.
 
-For terraces without driveways, we've got solutions too — armoured cable to rear yards, or front-mounted chargers with proper cable management.
+For terraces without driveways, we've got solutions too - armoured cable to rear yards, or front-mounted chargers with proper cable management.
 
-## Solar and EV — the combination
+## Solar and EV - the combination
 
-If you've got [solar panels](/services/solar-and-battery-installations/royton/) or you're considering them, an EV charger completes the picture. Export your solar at 15p/kWh during the day, charge your car at 7p/kWh overnight — you actually come out ahead on the arbitrage. In summer, charge directly from solar and your fuel cost is genuinely zero.
+If you've got [solar panels](/services/solar-and-battery-installations/royton/) or you're considering them, an EV charger completes the picture. Export your solar at 15p/kWh during the day, charge your car at 7p/kWh overnight - you actually come out ahead on the arbitrage. In summer, charge directly from solar and your fuel cost is genuinely zero.
 
 ## What we install
 
-[Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/) — we fit their smart charger range plus **SolaX** and **AlphaESS** units. Or bring your own charger and we'll install it. Done in a day, full NAPIT certification.
+[Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/) - we fit their smart charger range plus **SolaX** and **AlphaESS** units. Or bring your own charger and we'll install it. Done in a day, full NAPIT certification.
 
 **[Contact us](/contact/) for a free consultation and quote.**

--- a/src/services/electric-vehicle-charger-installations/saddleworth.md
+++ b/src/services/electric-vehicle-charger-installations/saddleworth.md
@@ -1,6 +1,6 @@
 ---
 title: EV Charger Installations in Saddleworth | Renegade Solar
-description: Professional EV charger installations across Saddleworth — Uppermill, Greenfield, Delph, Dobcross, Diggle. NAPIT-registered, solar integration. Based in Prestwich.
+description: Professional EV charger installations across Saddleworth - Uppermill, Greenfield, Delph, Dobcross, Diggle. NAPIT-registered, solar integration. Based in Prestwich.
 link_title: EV Charger Installs
 heading: EV Charger Installations in Saddleworth
 tags: [saddleworth]
@@ -8,17 +8,17 @@ icon: /assets/icons/car.svg
 gallery_tags: [electric-vehicle]
 ---
 
-EV charger installations across Saddleworth's villages — Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw. NAPIT-registered electrician based in Prestwich. Ashley personally assesses and installs every charger.
+EV charger installations across Saddleworth's villages - Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw. NAPIT-registered electrician based in Prestwich. Ashley personally assesses and installs every charger.
 
-## Two-car households — double the savings
+## Two-car households - double the savings
 
-Saddleworth's rural location means most households run at least one car, often two. That's potentially £1,350 a year in petrol for two commuters. Switch to EVs with home charging on Octopus Go (9.5p/kWh overnight) and you're looking at around £200 for both cars. That's over a thousand pounds saved annually — and it only gets better with [solar panels](/services/solar-and-battery-installations/saddleworth/).
+Saddleworth's rural location means most households run at least one car, often two. That's potentially £1,350 a year in petrol for two commuters. Switch to EVs with home charging on Octopus Go (9.5p/kWh overnight) and you're looking at around £200 for both cars. That's over a thousand pounds saved annually - and it only gets better with [solar panels](/services/solar-and-battery-installations/saddleworth/).
 
 A larger solar system on a Saddleworth detached home generates enough surplus in summer to charge both cars for free. In winter, overnight rates still keep you well under what petrol costs. The maths works especially well here because the bigger homes justify bigger solar systems with more surplus to divert to cars.
 
 ## Driveways and garages
 
-Most Saddleworth properties have off-street parking, so installation is straightforward. We mount the charger wherever makes sense for your parking arrangement — garage wall, exterior wall by the drive, wherever's practical. For properties where the consumer unit is at the other end of the house, we run heavy-duty armoured cable with full weatherproofing.
+Most Saddleworth properties have off-street parking, so installation is straightforward. We mount the charger wherever makes sense for your parking arrangement - garage wall, exterior wall by the drive, wherever's practical. For properties where the consumer unit is at the other end of the house, we run heavy-duty armoured cable with full weatherproofing.
 
 Need two charge points for two cars? We can do that in the same visit.
 

--- a/src/services/electric-vehicle-charger-installations/shaw.md
+++ b/src/services/electric-vehicle-charger-installations/shaw.md
@@ -10,11 +10,11 @@ gallery_tags: [electric-vehicle]
 
 EV charger installations in Shaw and Crompton from a NAPIT-registered electrician. Based in Prestwich, covering the whole [Oldham](/oldham/) borough. Ashley personally assesses and installs every charger.
 
-## Tram commuters — the smart setup
+## Tram commuters - the smart setup
 
 Shaw and Crompton's Metrolink stop with park-and-ride is perfect for EV owners. Charge overnight at 9.5p/kWh on Octopus Go, drive to the tram, take the 32-minute ride to Manchester city centre, come home to a charged car. Your daily commute costs pennies.
 
-Compare that to driving the whole way (£675/year in petrol) or using public rapid chargers at the other end (50-80p per kWh — more expensive than petrol). The tram-and-charge approach wins every time.
+Compare that to driving the whole way (£675/year in petrol) or using public rapid chargers at the other end (50-80p per kWh - more expensive than petrol). The tram-and-charge approach wins every time.
 
 ## Pair it with solar
 
@@ -22,7 +22,7 @@ Shaw's slightly larger properties often have room for a decent [solar system](/s
 
 ## What we install
 
-We're an [Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/) and fit their smart charger range — these schedule charging during the cheapest window automatically. Also fit **SolaX** and **AlphaESS** units that integrate with their solar and battery kit. Got your own charger already? We'll fit that too.
+We're an [Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/) and fit their smart charger range - these schedule charging during the cheapest window automatically. Also fit **SolaX** and **AlphaESS** units that integrate with their solar and battery kit. Got your own charger already? We'll fit that too.
 
 ## Installation
 

--- a/src/services/electrical-safety-inspections-eicr/bolton.md
+++ b/src/services/electrical-safety-inspections-eicr/bolton.md
@@ -13,9 +13,9 @@ tags: [bolton, eicr]
 
 Professional electrical safety inspections throughout Bolton from NAPIT-registered electricians. £150 plus VAT for all domestic properties with same day certificates - covering everything from traditional terraced houses to modern developments and commercial premises.
 
-## Bolton's Property Landscape
+## Bolton's housing stock
 
-As the UK's largest town with 280,000 residents, Bolton features a distinctive housing landscape shaped by its industrial heritage. When over 200 cotton mills operated here in the 1900s, rows of terraced mill worker cottages were built across the borough. Today, terraced and semi-detached properties make up 70% of Bolton's housing stock.
+As the UK's largest town with 280,000 residents, Bolton's housing reflects its industrial heritage. When over 200 cotton mills operated here in the 1900s, rows of terraced mill worker cottages were built across the borough. Today, terraced and semi-detached properties make up 70% of Bolton's housing stock.
 
 **Traditional terraced properties** throughout areas like Farnworth, Great Lever, Deane, and Tonge Moor often have electrical systems that have been upgraded incrementally over the decades. Original installations designed for gas lighting and minimal electrical demand have been adapted to handle modern requirements, but not always using the most appropriate methods.
 

--- a/src/services/electrical-safety-inspections-eicr/chadderton.md
+++ b/src/services/electrical-safety-inspections-eicr/chadderton.md
@@ -13,22 +13,22 @@ tags: [chadderton, eicr]
 
 ## What we see in Chadderton
 
-Chadderton's housing ranges from Victorian terraces around the Broadway area to 1930s semis and newer builds towards Foxdenton. The older terraces are the ones that keep us busy — electrical systems that started as basic lighting circuits in the 1900s, extended over the decades with whatever was standard practice at the time. Rewires layered on top of rewires, fuse boxes that predate RCD protection, and earthing arrangements that haven't kept pace with modern standards.
+Chadderton's housing ranges from Victorian terraces around the Broadway area to 1930s semis and newer builds towards Foxdenton. The older terraces are the ones that keep us busy - electrical systems that started as basic lighting circuits in the 1900s, extended over the decades with whatever was standard practice at the time. Rewires layered on top of rewires, fuse boxes that predate RCD protection, and earthing arrangements that haven't kept pace with modern standards.
 
-The semis are generally in better shape electrically, but we still find issues — particularly where extensions or loft conversions have been wired by someone cutting corners.
+The semis are generally in better shape electrically, but we still find issues - particularly where extensions or loft conversions have been wired by someone cutting corners.
 
 ## For landlords
 
-Chadderton has a decent-sized rental market. **EICR every 5 years plus one for each new tenant** — that's the law. Fines up to £30,000 if you don't comply. We do fast turnaround for landlords managing multiple properties, and if we find issues, we can handle the [remedial work](/services/) and get you compliant quickly.
+Chadderton has a decent-sized rental market. **EICR every 5 years plus one for each new tenant** - that's the law. Fines up to £30,000 if you don't comply. We do fast turnaround for landlords managing multiple properties, and if we find issues, we can handle the [remedial work](/services/) and get you compliant quickly.
 
-If you're also thinking about [solar](/services/solar-and-battery-installations/chadderton/) to meet the 2030 EPC C deadline, an EICR is a sensible first step — it tells you whether the consumer unit needs replacing before we connect a solar system to it.
+If you're also thinking about [solar](/services/solar-and-battery-installations/chadderton/) to meet the 2030 EPC C deadline, an EICR is a sensible first step - it tells you whether the consumer unit needs replacing before we connect a solar system to it.
 
 ## For buyers
 
-Average Chadderton property prices around £215k make it popular with first-time buyers. Get an EICR before you complete — if we find an outdated consumer unit or dodgy earthing, that's leverage in your negotiations and avoids a nasty surprise after you move in.
+Average Chadderton property prices around £215k make it popular with first-time buyers. Get an EICR before you complete - if we find an outdated consumer unit or dodgy earthing, that's leverage in your negotiations and avoids a nasty surprise after you move in.
 
 ## What's included
 
-Comprehensive visual inspection of all wiring, sockets, switches, and consumer units. Technical testing with calibrated equipment — continuity, insulation resistance, earth fault loop impedance, RCD checks. Same day certificate with a clear report in plain English.
+Comprehensive visual inspection of all wiring, sockets, switches, and consumer units. Technical testing with calibrated equipment - continuity, insulation resistance, earth fault loop impedance, RCD checks. Same day certificate with a clear report in plain English.
 
-**[Book your Chadderton EICR inspection — contact us today](/contact/)**
+**[Book your Chadderton EICR inspection - contact us today](/contact/)**

--- a/src/services/electrical-safety-inspections-eicr/lees.md
+++ b/src/services/electrical-safety-inspections-eicr/lees.md
@@ -15,11 +15,11 @@ tags: [lees, eicr]
 
 Lees sits where typical Oldham terraces start giving way to the larger properties heading up towards [Saddleworth](/saddleworth/). At the bottom end, you've got standard brick-built terraces and semis. Higher up towards Springhead and Grasscroft, the properties get bigger and older, with some stone construction.
 
-For the terraces, the common electrical issues are the same as across the Oldham borough — consumer units without modern RCD protection, earthing that's been left behind as regulations moved on, and circuits that have been extended without formal sign-off. For the larger properties, we sometimes find more complex wiring reflecting multiple rounds of renovation over the decades.
+For the terraces, the common electrical issues are the same as across the Oldham borough - consumer units without modern RCD protection, earthing that's been left behind as regulations moved on, and circuits that have been extended without formal sign-off. For the larger properties, we sometimes find more complex wiring reflecting multiple rounds of renovation over the decades.
 
 ## For landlords
 
-**EICR every 5 years plus one for each new tenant.** Fines up to £30,000 for non-compliance. If you're considering [solar panels](/services/solar-and-battery-installations/lees/) to meet the 2030 EPC C deadline, an EICR first tells you whether the consumer unit needs replacing — a job that can be done alongside the solar installation to save on labour costs.
+**EICR every 5 years plus one for each new tenant.** Fines up to £30,000 for non-compliance. If you're considering [solar panels](/services/solar-and-battery-installations/lees/) to meet the 2030 EPC C deadline, an EICR first tells you whether the consumer unit needs replacing - a job that can be done alongside the solar installation to save on labour costs.
 
 ## For buyers
 
@@ -27,6 +27,6 @@ Get an EICR before purchase. At Lees' average prices around £240k, it's worth s
 
 ## What's included
 
-Full visual inspection of wiring, sockets, switches, consumer units. Calibrated testing — continuity, insulation resistance, earth fault loop impedance, RCD checks. Same day certificate in plain English.
+Full visual inspection of wiring, sockets, switches, consumer units. Calibrated testing - continuity, insulation resistance, earth fault loop impedance, RCD checks. Same day certificate in plain English.
 
-**[Book your Lees EICR inspection — contact us today](/contact/)**
+**[Book your Lees EICR inspection - contact us today](/contact/)**

--- a/src/services/electrical-safety-inspections-eicr/oldham.md
+++ b/src/services/electrical-safety-inspections-eicr/oldham.md
@@ -9,11 +9,11 @@ tags: [oldham, eicr]
 
 # EICR Electrical Safety Inspections in Oldham
 
-Professional electrical safety inspections across the Oldham borough from experienced NAPIT-registered electricians. £150 plus VAT for all domestic properties — same day certificates, no waiting around.
+Professional electrical safety inspections across the Oldham borough from experienced NAPIT-registered electricians. £150 plus VAT for all domestic properties - same day certificates, no waiting around.
 
 ## Oldham's terraced housing stock
 
-Nearly half of all properties in Oldham are terraced houses — many dating back to the mill era. These properties present specific electrical challenges that need proper assessment.
+Nearly half of all properties in Oldham are terraced houses - many dating back to the mill era. These properties present specific electrical challenges that need proper assessment.
 
 **Traditional terraced properties** throughout Chadderton, Royton, Shaw, and central Oldham often have electrical systems that have evolved over decades. Original installations designed for basic lighting have been extended to cope with modern electrical demands, but not always to the best standards.
 
@@ -21,9 +21,9 @@ Nearly half of all properties in Oldham are terraced houses — many dating back
 
 **Modern developments** across the borough should be more straightforward, but even recent builds can have problems. Industry research shows electrical installation faults affect 1 in 5 new properties.
 
-## Our Oldham EICR Service — £150 plus VAT All Properties
+## Our Oldham EICR Service - £150 plus VAT All Properties
 
-**£150 plus VAT for any domestic property in Oldham** — whether you're in a compact terrace in Coldhurst or a detached home in Uppermill, the price stays the same. No travel charges from our Prestwich base.
+**£150 plus VAT for any domestic property in Oldham** - whether you're in a compact terrace in Coldhurst or a detached home in Uppermill, the price stays the same. No travel charges from our Prestwich base.
 
 Same day certificates and flexible scheduling. We can usually fit inspections in within a few days.
 
@@ -31,11 +31,11 @@ Same day certificates and flexible scheduling. We can usually fit inspections in
 
 ## For Oldham landlords
 
-Oldham has a significant buy-to-let market, particularly in central areas like St Mary's, Coldhurst, and Hollinwood. **EICR every 5 years plus one for each new tenant** — that's the legal requirement.
+Oldham has a significant buy-to-let market, particularly in central areas like St Mary's, Coldhurst, and Hollinwood. **EICR every 5 years plus one for each new tenant** - that's the legal requirement.
 
 Penalties for non-compliance are up to £30,000, plus local authorities can arrange remedial work and bill you for the costs. Give existing tenants the report within 28 days; new tenants get it before they move in.
 
-With the EPC C deadline coming in October 2030, many landlords are reviewing their properties anyway. An EICR is a good starting point — it tells you the condition of the electrical installation and whether upgrades are needed. If the consumer unit needs replacing, that work can be done alongside [solar panel installation](/services/solar-and-battery-installations/oldham/) to save on costs.
+With the EPC C deadline coming in October 2030, many landlords are reviewing their properties anyway. An EICR is a good starting point - it tells you the condition of the electrical installation and whether upgrades are needed. If the consumer unit needs replacing, that work can be done alongside [solar panel installation](/services/solar-and-battery-installations/oldham/) to save on costs.
 
 ## For property buyers
 
@@ -47,22 +47,22 @@ If we find problems like an outdated consumer unit or inadequate earthing, you c
 
 **Comprehensive visual inspection** of all visible electrical installations, including wiring, switches, sockets, and consumer units. We check for damage, signs of overheating, and general condition.
 
-**Technical testing** using calibrated professional equipment — continuity testing, insulation resistance measurement, earth fault loop impedance testing, and RCD operation checks.
+**Technical testing** using calibrated professional equipment - continuity testing, insulation resistance measurement, earth fault loop impedance testing, and RCD operation checks.
 
-**Same day documentation** — you receive your EICR certificate and detailed report explaining any findings in clear, understandable language.
+**Same day documentation** - you receive your EICR certificate and detailed report explaining any findings in clear, understandable language.
 
 ## When we find issues
 
-Straightforward assessment without pressure selling. If we discover electrical problems, we explain clearly what's wrong, why it matters, and what your options are. We can handle any remedial work discovered during inspection — no need to coordinate multiple contractors.
+Straightforward assessment without pressure selling. If we discover electrical problems, we explain clearly what's wrong, why it matters, and what your options are. We can handle any remedial work discovered during inspection - no need to coordinate multiple contractors.
 
 **[Need electrical work after an inspection? We handle all electrical services](/services/)**
 
 ## Oldham EICR questions
 
-**How quickly can you fit us in?** Usually within a few days. Oldham is well within our regular service area — we're just 13 minutes from Prestwich.
+**How quickly can you fit us in?** Usually within a few days. Oldham is well within our regular service area - we're just 13 minutes from Prestwich.
 
-**Any extra charges?** No travel charges — £150 plus VAT is the complete price for domestic EICR inspections across the Oldham borough.
+**Any extra charges?** No travel charges - £150 plus VAT is the complete price for domestic EICR inspections across the Oldham borough.
 
-**Do you cover the whole borough?** Yes — Oldham town centre, Chadderton, Royton, Shaw, Lees, Saddleworth, Hollinwood, and everywhere in between.
+**Do you cover the whole borough?** Yes - Oldham town centre, Chadderton, Royton, Shaw, Lees, Saddleworth, Hollinwood, and everywhere in between.
 
 **[Ready to book your Oldham EICR inspection? Contact us today](/contact/)**

--- a/src/services/electrical-safety-inspections-eicr/royton.md
+++ b/src/services/electrical-safety-inspections-eicr/royton.md
@@ -11,15 +11,15 @@ tags: [royton, eicr]
 
 £150 plus VAT for any domestic property in Royton. Same day certificates. No travel charges from Prestwich.
 
-## Royton's property market — protect your investment
+## Royton's property market - protect your investment
 
-Property prices in Royton have grown over 40% in five years. Whether you're buying into a growing market or you already own here, knowing the state of your electrics matters. An EICR tells you exactly where you stand — no guesswork.
+Property prices in Royton have grown over 40% in five years. Whether you're buying into a growing market or you already own here, knowing the state of your electrics matters. An EICR tells you exactly where you stand - no guesswork.
 
 Royton's terraces and older semis are the properties where we most often find issues: consumer units without RCD protection, earthing that doesn't meet current standards, circuits that have been extended without proper thought. These aren't necessarily dangerous right now, but they're the kind of things that need addressing, especially before you connect a [solar system](/services/solar-and-battery-installations/royton/) or [EV charger](/services/electric-vehicle-charger-installations/royton/).
 
 ## For landlords
 
-**EICR every 5 years plus one for each new tenant.** Fines up to £30,000 for non-compliance. With the EPC C deadline in 2030, many Royton landlords are reviewing their properties — an EICR tells you whether the consumer unit needs upgrading, which often has to happen before solar can go in anyway.
+**EICR every 5 years plus one for each new tenant.** Fines up to £30,000 for non-compliance. With the EPC C deadline in 2030, many Royton landlords are reviewing their properties - an EICR tells you whether the consumer unit needs upgrading, which often has to happen before solar can go in anyway.
 
 ## For buyers
 
@@ -27,6 +27,6 @@ Royton's price growth makes it attractive, but don't skip the electrical check. 
 
 ## What's included
 
-Full visual inspection plus calibrated technical testing — continuity, insulation resistance, earth fault loop impedance, RCD operation checks. Same day certificate with clear explanations.
+Full visual inspection plus calibrated technical testing - continuity, insulation resistance, earth fault loop impedance, RCD operation checks. Same day certificate with clear explanations.
 
-**[Book your Royton EICR inspection — contact us today](/contact/)**
+**[Book your Royton EICR inspection - contact us today](/contact/)**

--- a/src/services/electrical-safety-inspections-eicr/saddleworth.md
+++ b/src/services/electrical-safety-inspections-eicr/saddleworth.md
@@ -1,6 +1,6 @@
 ---
 title: EICR Electrical Safety Inspections in Saddleworth | £150 plus VAT Same Day Certificate
-description: Professional EICR electrical inspections across Saddleworth — Uppermill, Greenfield, Delph, Dobcross, Diggle. £150 plus VAT, same day certificates. NAPIT registered.
+description: Professional EICR electrical inspections across Saddleworth - Uppermill, Greenfield, Delph, Dobcross, Diggle. £150 plus VAT, same day certificates. NAPIT registered.
 link_title: EICR Inspection
 heading: EICR Inspections in Saddleworth
 icon: /assets/icons/check.svg
@@ -9,26 +9,26 @@ tags: [saddleworth, eicr]
 
 # EICR Electrical Safety Inspections in Saddleworth
 
-£150 plus VAT for any domestic property across Saddleworth — Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw. Same day certificates. No travel charges from Prestwich.
+£150 plus VAT for any domestic property across Saddleworth - Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw. Same day certificates. No travel charges from Prestwich.
 
 ## Stone-built properties and their quirks
 
-Many Saddleworth homes are older stone-built properties, and their electrics reflect that. Thick stone walls mean wiring routes can be unconventional — cables may follow unexpected paths through the building because chasing into stone isn't as simple as brick. Earthing arrangements in stone properties sometimes differ from standard brick-built homes, and we occasionally find moisture-related issues where stone walls meet electrical installations.
+Many Saddleworth homes are older stone-built properties, and their electrics reflect that. Thick stone walls mean wiring routes can be unconventional - cables may follow unexpected paths through the building because chasing into stone isn't as simple as brick. Earthing arrangements in stone properties sometimes differ from standard brick-built homes, and we occasionally find moisture-related issues where stone walls meet electrical installations.
 
-Properties that have been through multiple rounds of renovation — and most Saddleworth homes have — can end up with a patchwork of different-era wiring. A proper EICR sorts through what's been done when and tells you whether any of it needs attention.
+Properties that have been through multiple rounds of renovation - and most Saddleworth homes have - can end up with a patchwork of different-era wiring. A proper EICR sorts through what's been done when and tells you whether any of it needs attention.
 
-## For buyers — £393k average means the stakes are higher
+## For buyers - £393k average means the stakes are higher
 
-Saddleworth's premium property prices mean you're making a major investment. Hidden electrical issues in older stone properties can be expensive to put right — £150 for an EICR before purchase is cheap insurance against discovering a £3,000-5,000 rewiring need after you've completed.
+Saddleworth's premium property prices mean you're making a major investment. Hidden electrical issues in older stone properties can be expensive to put right - £150 for an EICR before purchase is cheap insurance against discovering a £3,000-5,000 rewiring need after you've completed.
 
 Older stone cottages and converted farm buildings in particular can harbour surprises. We'd rather find them before your money changes hands.
 
 ## For landlords
 
-**EICR every 5 years plus one for each new tenant.** Fines up to £30,000 for non-compliance. If you're also considering [solar panels](/services/solar-and-battery-installations/saddleworth/) to meet the 2030 EPC C deadline, start with an EICR — it identifies whether consumer unit or wiring upgrades are needed before a solar system can be connected.
+**EICR every 5 years plus one for each new tenant.** Fines up to £30,000 for non-compliance. If you're also considering [solar panels](/services/solar-and-battery-installations/saddleworth/) to meet the 2030 EPC C deadline, start with an EICR - it identifies whether consumer unit or wiring upgrades are needed before a solar system can be connected.
 
 ## What's included
 
-Full visual inspection of all accessible electrical installations. Calibrated testing — continuity, insulation resistance, earth fault loop impedance, RCD operation checks. Same day certificate with clear explanations of any findings.
+Full visual inspection of all accessible electrical installations. Calibrated testing - continuity, insulation resistance, earth fault loop impedance, RCD operation checks. Same day certificate with clear explanations of any findings.
 
-**[Book your Saddleworth EICR inspection — contact us today](/contact/)**
+**[Book your Saddleworth EICR inspection - contact us today](/contact/)**

--- a/src/services/electrical-safety-inspections-eicr/shaw.md
+++ b/src/services/electrical-safety-inspections-eicr/shaw.md
@@ -15,11 +15,11 @@ tags: [shaw, eicr]
 
 Shaw's traditional mill town terraces often have stone construction with thick walls. Electrically, this means wiring routes that might not follow the neat vertical and horizontal runs you'd expect in a brick-built house. Original stone terraces can have cables chased into plaster in unexpected places, and earthing arrangements that reflect whatever was standard when the property was last rewired.
 
-The newer and larger properties towards Crompton are generally more straightforward, but we still find issues — particularly in extensions and conversions where the standard of electrical work varies.
+The newer and larger properties towards Crompton are generally more straightforward, but we still find issues - particularly in extensions and conversions where the standard of electrical work varies.
 
 ## For buyers
 
-At average prices around £335k, Shaw properties are a significant purchase. An EICR before completion gives you ammunition if the electrics need work — or peace of mind if everything checks out. Either way, £150 is a small price for certainty on a six-figure investment.
+At average prices around £335k, Shaw properties are a significant purchase. An EICR before completion gives you ammunition if the electrics need work - or peace of mind if everything checks out. Either way, £150 is a small price for certainty on a six-figure investment.
 
 ## For landlords
 
@@ -27,6 +27,6 @@ At average prices around £335k, Shaw properties are a significant purchase. An 
 
 ## What's included
 
-Comprehensive visual inspection of all accessible electrical installations. Calibrated technical testing — continuity, insulation resistance, earth fault loop impedance, RCD operation checks. Same day certificate with a clear report.
+Comprehensive visual inspection of all accessible electrical installations. Calibrated technical testing - continuity, insulation resistance, earth fault loop impedance, RCD operation checks. Same day certificate with a clear report.
 
-**[Book your Shaw EICR inspection — contact us today](/contact/)**
+**[Book your Shaw EICR inspection - contact us today](/contact/)**

--- a/src/services/solar-and-battery-installations/altrincham.md
+++ b/src/services/solar-and-battery-installations/altrincham.md
@@ -14,11 +14,11 @@ MCS-certified solar panel and battery installations throughout Altrincham. Our N
 
 ## Solar Solutions for Altrincham Properties
 
-We install solar panels on a wide range of Altrincham properties. From **[Victorian and Edwardian homes in conservation areas](/solar-panels-conservation-areas-period-properties/)** to **modern detached and semi-detached properties**, we've got you covered. Our experience extends to contemporary new-builds, converted apartments in historic buildings, and commercial properties too. We skillfully work with slate roofs on period homes and tile roofs on newer properties, maximising energy generation while complementing your home's architectural style.
+We install solar panels on Altrincham properties of all types: **[Victorian and Edwardian homes in conservation areas](/solar-panels-conservation-areas-period-properties/)**, **modern detached and semi-detached properties**, contemporary new-builds, converted apartments, and commercial buildings. We work with slate roofs on period homes and tile roofs on newer properties.
 
 ## Solar Performance in Manchester's Climate
 
-Don't let Manchester's rainy reputation fool you! Solar panels perform excellently in our local climate. Modern panels generate electricity from daylight, not just direct sunshine, and actually operate **more efficiently in our cooler temperatures**. That famous Manchester rain? It helps keep your panels clean for peak efficiency. You'll be surprised how much electricity your system generates, even during the winter months.
+Solar panels work fine in Manchester's climate. Modern panels generate electricity from daylight rather than direct sunshine, and they operate **more efficiently in cooler temperatures**. Rain helps keep panels clean. Generation drops in winter but doesn't stop.
 
 ## Local Installer Advantages
 

--- a/src/services/solar-and-battery-installations/blackley.md
+++ b/src/services/solar-and-battery-installations/blackley.md
@@ -30,7 +30,7 @@ Many Blackley properties are ideal for [solar and battery installations](/servic
 - New-build developments with tile roofs
 - Flat-roofed properties, eg commercial buildings
 
-You might think that the constant Manchester rain means solar panels aren't viable, but the opposite is actually the case. Rain doesn't affect panel efficiency to any appreciable degree - it's all about the hours of sunshine, and in Manchester we get just as much of that as down south! And even better - the rain keeps the panels clean, removing dust and dirt build-up which blocks the sun's rays.
+Manchester rain doesn't make solar panels unviable. Panel efficiency depends on hours of daylight, and Manchester gets a similar amount to the south of England. The rain also helps keep panels clean, washing away dust and dirt build-up.
 
 We've found most homes in the M9 and M25 postcode areas can achieve excellent energy savings, even with north-facing roofs. We'll help you plan your panels to ensure the maximum possible efficiency regardless of your roof's orientation.
 
@@ -49,7 +49,7 @@ Our local knowledge means we:
 
 You won't find commission-hungry sales reps here. When you get in touch, you're speaking directly to Ashley - a qualified electrician who can actually answer your technical questions and won't recommend something unsuitable just to hit targets.
 
-We're not just another solar company - we're your neighbours. Our Prestwich base means:
+Our Prestwich base means:
 
 - Quick response times to Blackley
 - No call-out charges for local consultations

--- a/src/services/solar-and-battery-installations/bury.md
+++ b/src/services/solar-and-battery-installations/bury.md
@@ -24,13 +24,13 @@ With energy prices continuing to rise, locking in your own electricity generatio
 
 ## Manchester Weather Isn't a Problem
 
-Despite what people think about Manchester weather, solar panels work brilliantly here. They generate electricity from daylight, not just sunshine, and actually perform better in our cooler temperatures. That regular drizzle keeps your panels clean and operating at peak efficiency, much like how it keeps Bury Market's famous black pudding stalls looking fresh.
+Solar panels work fine in Manchester's climate. They generate from daylight rather than direct sunshine, and they run more efficiently at cooler temperatures. Rain helps keep panels clean.
 
-We've installed systems across Bury that consistently exceed expectations, even on north-facing roofs. Our experience with local properties means we know how to maximise your system's performance regardless of your roof's orientation.
+We've installed systems across Bury on a range of roof orientations, including north-facing where it makes sense.
 
 ## Local Knowledge, Personal Service
 
-We don't send salespeople - Ashley handles the survey and system design personally, so you get proper technical advice from someone who actually understands the electrical work involved. Being based in Prestwich means we understand Bury properties inside and out. We know how to work with older electrical systems in period homes, navigate planning considerations for different areas, understand typical energy usage patterns in local homes, and recommend the best battery solutions for your specific needs.
+We don't send salespeople. Ashley handles the survey and system design personally, so you get proper technical advice from a qualified electrician. Being based in Prestwich, we know Bury properties: older electrical systems in period homes, planning considerations across different areas, typical energy usage in local households, and which battery setup makes sense.
 
 ## Coverage Areas
 

--- a/src/services/solar-and-battery-installations/chadderton.md
+++ b/src/services/solar-and-battery-installations/chadderton.md
@@ -8,17 +8,17 @@ tags: [chadderton]
 gallery_tags: [solar-panels, failsworth]
 ---
 
-We're Renegade Solar, based in Prestwich and already installing solar in neighbouring [Failsworth](/services/solar-and-battery-installations/failsworth/). Chadderton's next door — we know the area and the housing stock.
+We're Renegade Solar, based in Prestwich and already installing solar in neighbouring [Failsworth](/services/solar-and-battery-installations/failsworth/). Chadderton's next door - we know the area and the housing stock.
 
 Ashley, a qualified electrician, handles your survey and installation personally. No sales team, no subcontractors.
 
 ## Chadderton properties
 
-Chadderton sits between Failsworth and Royton, straddling the M60. The housing is a proper mix — Victorian terraces around Chadderton Hall Park, 1930s semis on the estates off Burnley Lane, and newer builds towards Foxdenton. Each needs a different approach.
+Chadderton sits between Failsworth and Royton, straddling the M60. The housing is a proper mix - Victorian terraces around Chadderton Hall Park, 1930s semis on the estates off Burnley Lane, and newer builds towards Foxdenton. Each needs a different approach.
 
-The terraces along Broadway and Middleton Road typically suit 3-4kW systems. With roofs running parallel to the street, you'll often get east and west slopes rather than south-facing — but that's not a problem. Panels on both sides generate more total energy and match when you actually use electricity (mornings and evenings) rather than producing everything at midday.
+The terraces along Broadway and Middleton Road typically suit 3-4kW systems. With roofs running parallel to the street, you'll often get east and west slopes rather than south-facing - but that's not a problem. Panels on both sides generate more total energy and match when you actually use electricity (mornings and evenings) rather than producing everything at midday.
 
-The semis have more roof space — usually room for a 4-6kW system. If you've got a south-facing rear roof, that's ideal, but we work with whatever orientation you've got.
+The semis have more roof space - usually room for a 4-6kW system. If you've got a south-facing rear roof, that's ideal, but we work with whatever orientation you've got.
 
 ## M60 commuters
 
@@ -26,14 +26,14 @@ Chadderton's M60 access is one of its big selling points. If you're commuting by
 
 ## Already working next door
 
-We've completed installations throughout Failsworth — you can see examples in our [gallery](/gallery/). Chadderton is the same drive for us. No travel charges, and if anything ever needs sorting, we're nearby.
+We've completed installations throughout Failsworth - you can see examples in our [gallery](/gallery/). Chadderton is the same drive for us. No travel charges, and if anything ever needs sorting, we're nearby.
 
 ## What to expect
 
-A 4kW system in this area produces around 3,250 kWh per year. For a typical Chadderton household, that's savings of £350-570 annually on energy bills. Solar also adds around 4% to your property value — worth having on a £215k home.
+A 4kW system in this area produces around 3,250 kWh per year. For a typical Chadderton household, that's savings of £350-570 annually on energy bills. Solar also adds around 4% to your property value - worth having on a £215k home.
 
-As an [MCS-certified installer](/accreditations/mcs-certified/), your system qualifies for Smart Export Guarantee payments — you get paid for electricity you export to the grid.
+As an [MCS-certified installer](/accreditations/mcs-certified/), your system qualifies for Smart Export Guarantee payments - you get paid for electricity you export to the grid.
 
 ## Get started
 
-[Contact us](/contact/) for a no-obligation chat about solar for your Chadderton property. We'll give you honest advice — and we'll tell you if it won't work.
+[Contact us](/contact/) for a no-obligation chat about solar for your Chadderton property. We'll give you honest advice - and we'll tell you if it won't work.

--- a/src/services/solar-and-battery-installations/failsworth.md
+++ b/src/services/solar-and-battery-installations/failsworth.md
@@ -20,7 +20,7 @@ As an MCS-certified installer (certification number [NAP-66870](https://mcscerti
 
 ## Solar Panels Work Well in Failsworth
 
-Manchester weather doesn't stop solar panels generating electricity. In fact, rain keeps them clean by washing away dust and dirt that would otherwise reduce efficiency. Your panels will generate power all year round, with summer months covering most of your usage and winter still providing decent returns.
+Manchester weather doesn't stop solar panels generating electricity, and rain keeps them clean by washing away dust and dirt. Panels generate power year-round, with summer months covering most of your usage and winter still providing decent returns.
 
 According to [Ofgem's latest data](https://www.ofgem.gov.uk/publications/smart-export-guarantee-annual-report-april-2023-march-2024), over £30 million was paid out last year through the Smart Export Guarantee scheme. That's real money going back to homeowners who've invested in solar.
 

--- a/src/services/solar-and-battery-installations/lees.md
+++ b/src/services/solar-and-battery-installations/lees.md
@@ -10,22 +10,22 @@ gallery_tags: [solar-panels]
 
 We're Renegade Solar, based in Prestwich, covering the whole [Oldham](/oldham/) borough. Ashley, a qualified electrician, handles every survey and installation personally.
 
-## Lees — between town and moor
+## Lees - between town and moor
 
-Lees sits at the point where Oldham starts climbing towards [Saddleworth](/saddleworth/). The housing reflects that transition — you've got terraces and semis on the lower streets that are typical Oldham borough stock, and as you head uphill towards Springhead and Grasscroft, the properties get bigger, the views get better, and the roofs get more interesting.
+Lees sits at the point where Oldham starts climbing towards [Saddleworth](/saddleworth/). The housing reflects that transition - you've got terraces and semis on the lower streets that are typical Oldham borough stock, and as you head uphill towards Springhead and Grasscroft, the properties get bigger, the views get better, and the roofs get more interesting.
 
-The terraces around Lees centre suit 3-4kW systems. The semis and detached homes up the hill can take 4-6kW, sometimes more if the roof allows it. Average property prices around £240k mean solar's a proportionally significant investment — and the returns are genuine, with savings of £350-570 a year on typical energy bills.
+The terraces around Lees centre suit 3-4kW systems. The semis and detached homes up the hill can take 4-6kW, sometimes more if the roof allows it. Average property prices around £240k mean solar's a proportionally significant investment - and the returns are genuine, with savings of £350-570 a year on typical energy bills.
 
 ## Grants worth knowing about
 
-Oldham Council runs an active LA Flex scheme — if your household income is under £31,000, you may qualify for grant funding towards solar panels, batteries, or heat pumps. The scheme runs until December 2026 but budgets may run out early.
+Oldham Council runs an active LA Flex scheme - if your household income is under £31,000, you may qualify for grant funding towards solar panels, batteries, or heat pumps. The scheme runs until December 2026 but budgets may run out early.
 
 On top of that, 0% VAT on domestic solar installations runs until 2027, and [MCS certification](/accreditations/mcs-certified/) (which we have) means your system qualifies for Smart Export Guarantee payments.
 
 ## Heading towards Saddleworth
 
-If your property is further up towards Springhead or Grasscroft, you're getting into territory where stone slate roofs and higher wind exposure become factors. We cover this in detail on our [Saddleworth page](/services/solar-and-battery-installations/saddleworth/) — but the short version is we account for wind loading in every design, and we're upfront about any additional complexity or cost.
+If your property is further up towards Springhead or Grasscroft, you're getting into territory where stone slate roofs and higher wind exposure become factors. We cover this in detail on our [Saddleworth page](/services/solar-and-battery-installations/saddleworth/) - but the short version is we account for wind loading in every design, and we're upfront about any additional complexity or cost.
 
 ## Get started
 
-[Contact us](/contact/) for honest advice about solar for your Lees property. No salespeople — just a qualified electrician who'll tell you what works and what doesn't.
+[Contact us](/contact/) for honest advice about solar for your Lees property. No salespeople - just a qualified electrician who'll tell you what works and what doesn't.

--- a/src/services/solar-and-battery-installations/middleton.md
+++ b/src/services/solar-and-battery-installations/middleton.md
@@ -10,30 +10,24 @@ tags: [middleton]
 gallery_tags: [solar-panels]
 ---
 
-Just a stone's throw from our Prestwich base, Middleton is an area we know like the back of our hand. As your local solar energy experts, we've helped countless Middleton homeowners transform their energy usage with custom solar solutions tailored to their specific property styles.
+Middleton is a short drive from our Prestwich base, and we've installed solar across the area. Middleton's housing ranges from Victorian terraces to modern new-builds, and we work with all property types.
 
-Middleton's diverse housing stock - from characterful Victorian terraces to modern new-builds - presents unique opportunities for solar installations. **Every home has potential** for renewable energy generation, and we're experts at finding the perfect solution for your specific property.
+## System sizing for Middleton properties
 
-## Unlock Your Home's Energy Potential
+South-facing roofs are ideal but east-west orientations also work well. Panels on both east and west slopes generate more total energy across the day than a south-only setup, and the spread of generation matches when most households actually use electricity.
 
-Your Middleton home could be perfectly positioned to harness solar power. Whether you have an ideal south-facing roof or an east-west orientation, you could generate impressive amounts of clean energy with a customised setup. You might be surprised at just how efficient your system could be, regardless of your property type.
+Pairing solar panels with a [home battery system](/services/home-battery-installations/) lets you store surplus generation and use it later. On a time-of-use tariff like Octopus Go, the payback maths work better than on standard flat-rate tariffs.
 
-When you pair solar panels with a [home battery system](/services/home-battery-installations/), you could create an even more powerful energy solution. You'll be able to store excess energy produced during sunny periods and use it exactly when you need it - **dramatically cutting your electricity bills** while reducing your carbon footprint.
+## Costs and returns
 
-## Transform Your Energy Future
+A 4kW system in Middleton produces around 3,250 kWh per year. For a typical household that's £350-570 off your annual energy bills, plus around 4% added to your property value. Solar also bumps your EPC rating by roughly one band.
 
-You could significantly transform your home's energy profile with a tailored solar solution. Middleton residents are increasingly embracing renewable energy, and it's easy to see why. Beyond the environmental benefits, you could achieve remarkable savings on your energy bills - particularly valuable as traditional energy costs continue to rise.
+## Why us
 
-With the right solar setup, you could generate enough power to cover most of your electricity needs during spring and summer months. Add a battery system and you'll have crucial backup power during evening hours and cloudier days.
+Ashley personally handles surveys and system design, so you get technical advice from a qualified electrician rather than a salesperson working from a script. Being minutes from Middleton means quick response times for surveys and any aftercare. We're MCS-certified (certification number [NAP-66870](https://mcscertified.com/find-an-installer/)) and Ashley oversees everything from survey through to commissioning. [Electrical testing](/services/electrical-testing/) is part of every install.
 
-## Expert Support Throughout Your Solar Journey
+## Areas we cover in Middleton
 
-Ashley personally handles surveys and system design - you won't be passed to a salesperson working from a script. That means you get technical advice from someone who actually understands your electrical setup, not generic recommendations. Being just minutes away from Middleton means you'll receive **prompt, attentive service** whenever you need it. You won't have to worry about planning considerations as we have excellent relationships with Rochdale Council for any permissions you might need.
+Alkrington, Birch, Bowlee, Boarshaw, Hollins, Langley, Mills Hill, Rhodes, and Middleton Junction.
 
-You could have complete peace of mind with our MCS-certified installation service (certification number [NAP-66870](https://mcscertified.com/find-an-installer/)). Ashley oversees everything from the initial survey through to commissioning your system. With our comprehensive [electrical testing](/services/electrical-testing/), you can be confident your installation meets the highest safety standards.
-
-## Available Throughout Middleton
-
-You can access our expert solar services no matter where you're located in Middleton. Whether you're in Alkrington, Birch, Bowlee, Boarshaw, Hollins, Langley, Mills Hill, Rhodes, or Middleton Junction, you're just a call away from transforming your home's energy future.
-
-Curious about what you could achieve with solar at your Middleton home? [Contact us](/contact/) today for a friendly, no-pressure chat about your options. You could be making smarter energy choices sooner than you think!
+[Contact us](/contact/) for a no-obligation quote. If solar won't work on your property, we'll tell you.

--- a/src/services/solar-and-battery-installations/oldham.md
+++ b/src/services/solar-and-battery-installations/oldham.md
@@ -1,6 +1,6 @@
 ---
 title: Solar Panel Installer in Oldham | Renegade Solar
-description: MCS-certified solar panel and battery installations across Oldham. Terraced house specialists just 13 minutes from Prestwich. No salespeople — Ashley surveys, designs, and installs.
+description: MCS-certified solar panel and battery installations across Oldham. Terraced house specialists just 13 minutes from Prestwich. No salespeople - Ashley surveys, designs, and installs.
 link_title: Solar Panel Installations
 heading: Solar Panel Installer in Oldham
 icon: /assets/icons/solar-panel.svg
@@ -8,17 +8,17 @@ tags: [oldham]
 gallery_tags: [solar-panels, failsworth]
 ---
 
-Looking for a solar panel installer in Oldham? We're Renegade Solar, based in Prestwich — just 13 minutes down the road. We already work in [Failsworth](/services/solar-and-battery-installations/failsworth/) and cover the whole Oldham borough including [Chadderton](/chadderton/), [Royton](/royton/), [Shaw](/shaw/), [Lees](/lees/), and [Saddleworth](/saddleworth/).
+Looking for a solar panel installer in Oldham? We're Renegade Solar, based in Prestwich - just 13 minutes down the road. We already work in [Failsworth](/services/solar-and-battery-installations/failsworth/) and cover the whole Oldham borough including [Chadderton](/chadderton/), [Royton](/royton/), [Shaw](/shaw/), [Lees](/lees/), and [Saddleworth](/saddleworth/).
 
 Ashley, a qualified electrician, handles your survey, designs your system, and oversees the installation personally. No salespeople, no handoffs, no miscommunication.
 
 ## Oldham's terraced houses and solar
 
-Nearly half of all properties in Oldham are terraced houses — the old Accrington red-brick mill worker homes that run through Chadderton, Royton, Shaw, and central Oldham. We know these properties well.
+Nearly half of all properties in Oldham are terraced houses - the old Accrington red-brick mill worker homes that run through Chadderton, Royton, Shaw, and central Oldham. We know these properties well.
 
-Many Oldham terraces have roofs running parallel to the street, giving east and west slopes rather than south-facing. This isn't the problem some installers make it out to be. East-west setups actually match household usage better — you get morning generation when you're getting ready and evening generation when you're cooking dinner, rather than peak output at midday when nobody's home. You can install panels on both slopes, potentially generating more total energy than a south-only setup.
+Many Oldham terraces have roofs running parallel to the street, giving east and west slopes rather than south-facing. This isn't the problem some installers make it out to be. East-west setups actually match household usage better - you get morning generation when you're getting ready and evening generation when you're cooking dinner, rather than peak output at midday when nobody's home. You can install panels on both slopes, potentially generating more total energy than a south-only setup.
 
-For a typical 2-3 bed mid-terrace, we can usually fit a 3-4kW system that'll make a real difference to your bills. Oldham households spend around £1,850 a year on energy — a well-sized solar system can save £350-570 annually, and more with battery storage or a smart tariff.
+For a typical 2-3 bed mid-terrace, we can usually fit a 3-4kW system that'll make a real difference to your bills. Oldham households spend around £1,850 a year on energy - a well-sized solar system can save £350-570 annually, and more with battery storage or a smart tariff.
 
 ## System sizing for Oldham properties
 
@@ -32,44 +32,44 @@ A 4kW system in Oldham produces around 3,250 kWh per year. That's enough to cove
 
 ## Chimneys, shading, and honest advice
 
-Chimney stacks on terraced houses cause shading — it's unavoidable. We assess actual shading patterns at your property and use panel-level optimisers or micro-inverters where needed so one shaded panel doesn't drag down the whole array. If your roof genuinely won't work, we'll tell you. We'd rather be honest than sell you a system that underperforms.
+Chimney stacks on terraced houses cause shading - it's unavoidable. We assess actual shading patterns at your property and use panel-level optimisers or micro-inverters where needed so one shaded panel doesn't drag down the whole array. If your roof genuinely won't work, we'll tell you. We'd rather be honest than sell you a system that underperforms.
 
-## Battery storage — when it makes sense
+## Battery storage - when it makes sense
 
 For Oldham terraces with lower energy consumption (2,500-3,000 kWh/year), a battery's payback on a standard flat-rate tariff can stretch to 10-12 years. That's uncomfortably close to the warranty lifespan.
 
 Our honest advice: if you're on a standard tariff with modest consumption, maximise your panel capacity first and add a battery later. But if you're on a time-of-use tariff like [Octopus Go or Agile](https://octopus.energy/tariffs/), payback drops to 7-10 years and the economics work much better. As an [Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/), we can help you get set up on the right tariff.
 
-For larger homes in Saddleworth with higher consumption, batteries make sense from day one — bigger systems, more excess generation to store, and greater savings.
+For larger homes in Saddleworth with higher consumption, batteries make sense from day one - bigger systems, more excess generation to store, and greater savings.
 
 ## Consumer unit upgrades
 
-Many Oldham terraces still have old fuse boxes that don't meet current safety standards. If yours needs upgrading, we'll include it in your quote upfront — no surprises. This is particularly common in older properties built before 2008 that lack proper RCD protection.
+Many Oldham terraces still have old fuse boxes that don't meet current safety standards. If yours needs upgrading, we'll include it in your quote upfront - no surprises. This is particularly common in older properties built before 2008 that lack proper RCD protection.
 
 ## Oldham Council backs green energy
 
-Oldham declared a Climate Emergency in 2019 and became the UK's first "Green New Deal Council" in 2020. The council runs Oldham Community Power, putting solar on local schools, and secured £20m in Levelling Up funding for green initiatives. There's a local culture here that's receptive to solar — you're joining a movement, not starting one.
+Oldham declared a Climate Emergency in 2019 and became the UK's first "Green New Deal Council" in 2020. The council runs Oldham Community Power, putting solar on local schools, and secured £20m in Levelling Up funding for green initiatives. There's a local culture here that's receptive to solar - you're joining a movement, not starting one.
 
 ## Grants and incentives
 
 **0% VAT** on domestic solar and battery installations until 2027.
 
-**Smart Export Guarantee**: As an [MCS-certified installer](/accreditations/mcs-certified/) (certification number [NAP-66870](https://mcscertified.com/find-an-installer/)), we ensure your system qualifies for SEG payments — you get paid 5-15p per kWh for electricity you export back to the grid.
+**Smart Export Guarantee**: As an [MCS-certified installer](/accreditations/mcs-certified/) (certification number [NAP-66870](https://mcscertified.com/find-an-installer/)), we ensure your system qualifies for SEG payments - you get paid 5-15p per kWh for electricity you export back to the grid.
 
 **ECO4 and Local Authority Flex**: Oldham Council runs an active LA Flex scheme for households with income under £31,000. Eligible measures include solar panels, batteries, and heat pumps. The scheme runs until December 2026, but budgets may run out earlier.
 
-Solar panels also improve your EPC rating by approximately one band — particularly relevant if you're a landlord facing the EPC C deadline by October 2030.
+Solar panels also improve your EPC rating by approximately one band - particularly relevant if you're a landlord facing the EPC C deadline by October 2030.
 
 ## Why choose Renegade over competitors already in Oldham?
 
 There are installers based in the Oldham area, and plenty of national companies who'll send someone out. Here's what makes us different:
 
-- **One person, start to finish** — Ashley surveys, designs, and installs. No handoffs between sales teams and fitting crews.
+- **One person, start to finish** - Ashley surveys, designs, and installs. No handoffs between sales teams and fitting crews.
 - **[{{ reviews.averageRating | round: 2 }}/10 Checkatrade rating](https://www.checkatrade.com/trades/renegadeelectrical/)** from {{ reviews.total }}+ verified reviews.
-- **All the certifications that matter** — [MCS](/accreditations/mcs-certified/), [NAPIT](/accreditations/napit/), [TrustMark](/accreditations/trustmark/), [HIES Consumer Code](/accreditations/hies-consumer-code/), [Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/).
-- **We'll tell you if it won't work** — especially important for Oldham's terraced stock where some properties genuinely aren't suitable.
-- **2 years routine maintenance included** — we don't disappear after installation.
-- **No travel charges** — we're just down the road in Prestwich.
+- **All the certifications that matter** - [MCS](/accreditations/mcs-certified/), [NAPIT](/accreditations/napit/), [TrustMark](/accreditations/trustmark/), [HIES Consumer Code](/accreditations/hies-consumer-code/), [Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/).
+- **We'll tell you if it won't work** - especially important for Oldham's terraced stock where some properties genuinely aren't suitable.
+- **2 years routine maintenance included** - we don't disappear after installation.
+- **No travel charges** - we're just down the road in Prestwich.
 
 ## Nearby areas we cover
 
@@ -77,4 +77,4 @@ We also serve [Failsworth](/services/solar-and-battery-installations/failsworth/
 
 ## Get started
 
-[Contact us](/contact/) for a no-obligation chat about solar for your Oldham property. Ashley will respond within 48 hours to arrange a survey — and he'll give you honest advice about what'll work and what won't.
+[Contact us](/contact/) for a no-obligation chat about solar for your Oldham property. Ashley will respond within 48 hours to arrange a survey - and he'll give you honest advice about what'll work and what won't.

--- a/src/services/solar-and-battery-installations/royton.md
+++ b/src/services/solar-and-battery-installations/royton.md
@@ -10,23 +10,23 @@ gallery_tags: [solar-panels]
 
 We're Renegade Solar, based in Prestwich, serving the whole [Oldham](/oldham/) borough. Ashley, a qualified electrician, surveys your property and installs your system personally.
 
-## Royton — a growing area
+## Royton - a growing area
 
-Royton property prices have grown over 40% in the last five years. Homeowners here are putting money into their homes, and solar is one of the best returns you'll get — it adds around 4% to your property value while cutting your energy bills from day one.
+Royton property prices have grown over 40% in the last five years. Homeowners here are putting money into their homes, and solar is one of the best returns you'll get - it adds around 4% to your property value while cutting your energy bills from day one.
 
 The housing stock is mostly terraces and semis around Royton centre and along Rochdale Road, with newer family homes on the fringes towards [Shaw](/shaw/). The terraces typically suit 3-4kW systems; the semis and larger homes can take 4-6kW.
 
 ## East-west roofs are fine
 
-Many of Royton's terraces have roofs running parallel to the street. Some installers will tell you south-facing is the only option worth having — we disagree. Panels on both east and west slopes generate more total energy than south-only, and the spread of generation across morning and evening actually matches when you're using electricity. We design systems around your actual roof, not a textbook ideal.
+Many of Royton's terraces have roofs running parallel to the street. Some installers will tell you south-facing is the only option worth having - we disagree. Panels on both east and west slopes generate more total energy than south-only, and the spread of generation across morning and evening actually matches when you're using electricity. We design systems around your actual roof, not a textbook ideal.
 
-## Batteries — honest advice
+## Batteries - honest advice
 
-For a typical Royton terrace using 2,500-3,000 kWh a year, a battery on a standard tariff has a long payback. Our advice: maximise your panels first. If you're on a time-of-use tariff like [Octopus Go](https://octopus.energy/tariffs/), the battery maths change — payback drops to 7-10 years and the savings are real. As an [Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/), we'll help you work out what makes sense for your usage.
+For a typical Royton terrace using 2,500-3,000 kWh a year, a battery on a standard tariff has a long payback. Our advice: maximise your panels first. If you're on a time-of-use tariff like [Octopus Go](https://octopus.energy/tariffs/), the battery maths change - payback drops to 7-10 years and the savings are real. As an [Octopus Energy Trusted Partner](/accreditations/octopus-trusted-partner/), we'll help you work out what makes sense for your usage.
 
 ## Old fuse boxes
 
-A lot of Royton's older properties still have fuse boxes that don't meet current standards. If yours needs upgrading, we include it in the quote — it's not a nasty surprise that appears after the survey.
+A lot of Royton's older properties still have fuse boxes that don't meet current standards. If yours needs upgrading, we include it in the quote - it's not a nasty surprise that appears after the survey.
 
 ## Get started
 

--- a/src/services/solar-and-battery-installations/saddleworth.md
+++ b/src/services/solar-and-battery-installations/saddleworth.md
@@ -1,6 +1,6 @@
 ---
 title: Solar Panel Installer in Saddleworth | Renegade Solar
-description: MCS-certified solar panel and battery installations in Saddleworth — Uppermill, Greenfield, Delph, Dobcross, Diggle, Denshaw. Expert advice on stone-built properties and conservation areas.
+description: MCS-certified solar panel and battery installations in Saddleworth - Uppermill, Greenfield, Delph, Dobcross, Diggle, Denshaw. Expert advice on stone-built properties and conservation areas.
 link_title: Solar Panel Installations
 heading: Solar Panel Installer in Saddleworth
 icon: /assets/icons/solar-panel.svg
@@ -10,36 +10,36 @@ gallery_tags: [solar-panels]
 
 We're Renegade Solar, based in Prestwich, covering the whole [Oldham](/oldham/) borough including Uppermill, Greenfield, Delph, Dobcross, Diggle, and Denshaw.
 
-Saddleworth is a different proposition from the rest of Oldham. Bigger homes, higher energy bills, more roof space, and properties worth investing in (average around £393k). But it also comes with stone slate roofs, conservation areas, and exposed hilltop locations. Ashley, a qualified electrician, personally surveys and installs every system — and he'll be straight with you about what your property needs.
+Saddleworth is a different proposition from the rest of Oldham. Bigger homes, higher energy bills, more roof space, and properties worth investing in (average around £393k). But it also comes with stone slate roofs, conservation areas, and exposed hilltop locations. Ashley, a qualified electrician, personally surveys and installs every system - and he'll be straight with you about what your property needs.
 
 ## Bigger homes, bigger savings
 
-Saddleworth's detached homes can accommodate 6-8kW+ systems — 15-20 panels — producing enough to make a serious dent in higher energy bills. The payback is faster when you're offsetting more consumption, and with more surplus generation to store, [battery storage](/services/home-battery-installations/) makes financial sense from day one here.
+Saddleworth's detached homes can accommodate 6-8kW+ systems - 15-20 panels - producing enough to make a serious dent in higher energy bills. The payback is faster when you're offsetting more consumption, and with more surplus generation to store, [battery storage](/services/home-battery-installations/) makes financial sense from day one here.
 
 Semi-detached properties suit 4-6kW systems. Good roof space and decent orientation make most Saddleworth semis strong candidates.
 
 ## Stone slate roofs
 
-Many Saddleworth properties have Yorkstone or stone flag roofs. Solar can go on these, but it's more involved than a standard tile installation. Standard shortcut mounting systems don't work — you need rafter-mount brackets with lead flashing, and the slates have to be carefully removed and replaced. It takes longer and costs more (expect a premium over standard installations), but it's absolutely doable. We'll be upfront about the time and cost during your survey.
+Many Saddleworth properties have Yorkstone or stone flag roofs. Solar can go on these, but it's more involved than a standard tile installation. Standard shortcut mounting systems don't work - you need rafter-mount brackets with lead flashing, and the slates have to be carefully removed and replaced. It takes longer and costs more (expect a premium over standard installations), but it's absolutely doable. We'll be upfront about the time and cost during your survey.
 
 If your stone slates are in poor condition and replacement slates are hard to source, we'll tell you. We'd rather have that conversation before taking your deposit than halfway through the job.
 
 ## Exposed sites and wind loading
 
-Parts of Saddleworth are 300-400m above sea level. The altitude doesn't meaningfully affect solar output, but wind loading is a proper consideration. Exposed hilltop properties need heavier-duty fixings and MCS 012 requires altitude correction factors in the wind load calculations. We factor this into every design — panels must be fixed to rafters, not tiling battens, which matters most at exposed sites.
+Parts of Saddleworth are 300-400m above sea level. The altitude doesn't meaningfully affect solar output, but wind loading is a proper consideration. Exposed hilltop properties need heavier-duty fixings and MCS 012 requires altitude correction factors in the wind load calculations. We factor this into every design - panels must be fixed to rafters, not tiling battens, which matters most at exposed sites.
 
 ## Conservation areas
 
-Several Saddleworth villages have conservation area designations. Roof-mounted solar panels are generally permitted development — no planning permission needed — provided they don't protrude more than 200mm from the roof slope or exceed the ridge line.
+Several Saddleworth villages have conservation area designations. Roof-mounted solar panels are generally permitted development - no planning permission needed - provided they don't protrude more than 200mm from the roof slope or exceed the ridge line.
 
-Listed buildings are a different matter — they always need Listed Building Consent. For listed properties where roof panels aren't possible, ground-mounted systems or standalone [battery installations](/services/home-battery-installations/) with a time-of-use tariff are alternatives worth considering.
+Listed buildings are a different matter - they always need Listed Building Consent. For listed properties where roof panels aren't possible, ground-mounted systems or standalone [battery installations](/services/home-battery-installations/) with a time-of-use tariff are alternatives worth considering.
 
 We'd recommend applying for a Lawful Development Certificate before installation in conservation areas. It's a belt-and-braces measure and we can guide you through it.
 
 ## EV charging
 
-Most Saddleworth households run at least one car. Combine solar with an [EV charger](/services/electric-vehicle-charger-installations/saddleworth/) and your fuel costs could drop to near zero in summer — a 4.5kWh daily commute is easily covered by surplus generation from a decent-sized system.
+Most Saddleworth households run at least one car. Combine solar with an [EV charger](/services/electric-vehicle-charger-installations/saddleworth/) and your fuel costs could drop to near zero in summer - a 4.5kWh daily commute is easily covered by surplus generation from a decent-sized system.
 
 ## Get started
 
-[Contact us](/contact/) to discuss solar for your Saddleworth property. Ashley will give you straightforward advice about what'll work, what the complications are, and what it'll cost. No pressure — just honest answers.
+[Contact us](/contact/) to discuss solar for your Saddleworth property. Ashley will give you straightforward advice about what'll work, what the complications are, and what it'll cost. No pressure - just honest answers.

--- a/src/services/solar-and-battery-installations/shaw.md
+++ b/src/services/solar-and-battery-installations/shaw.md
@@ -12,11 +12,11 @@ We're Renegade Solar, based in Prestwich, covering the whole [Oldham](/oldham/) 
 
 ## Shaw and Crompton
 
-Shaw's a step up from central Oldham — slightly higher ground, a mix of traditional stone-built terraces and larger, newer properties. Average prices around £335k reflect an area where people are settled and willing to invest in their homes.
+Shaw's a step up from central Oldham - slightly higher ground, a mix of traditional stone-built terraces and larger, newer properties. Average prices around £335k reflect an area where people are settled and willing to invest in their homes.
 
 The older terraces around Shaw centre have solid roof structures, typically Yorkstone or concrete tile. These suit 3-4kW systems well. The larger properties towards Crompton and up towards [Saddleworth](/saddleworth/) have more roof space for 4-6kW+ systems, and their higher energy consumption means faster payback.
 
-## Tram and solar — a good combination
+## Tram and solar - a good combination
 
 Shaw and Crompton has a Metrolink stop with park-and-ride. If you drive to the tram, pair solar with an [EV charger](/services/electric-vehicle-charger-installations/shaw/) and your commute gets dramatically cheaper. Charge overnight on a cheap tariff, drive to the stop, take the tram into Manchester. You come home to a charged car and barely notice the cost.
 
@@ -26,8 +26,8 @@ Shaw's larger properties and higher consumption levels make batteries a stronger
 
 ## Higher ground, more wind?
 
-Shaw sits higher than central Oldham. The altitude doesn't meaningfully affect solar output, but we do factor wind loading into every design — exposed properties need heavier-duty fixings, and we calculate this as standard. It's part of proper engineering, not an optional extra.
+Shaw sits higher than central Oldham. The altitude doesn't meaningfully affect solar output, but we do factor wind loading into every design - exposed properties need heavier-duty fixings, and we calculate this as standard. It's part of proper engineering, not an optional extra.
 
 ## Get started
 
-[Contact us](/contact/) to discuss solar for your Shaw property. Honest advice, no pressure — if it won't work, we'll say so.
+[Contact us](/contact/) to discuss solar for your Shaw property. Honest advice, no pressure - if it won't work, we'll say so.

--- a/src/services/solar-and-battery-installations/whitefield.md
+++ b/src/services/solar-and-battery-installations/whitefield.md
@@ -23,7 +23,7 @@ And we've even installed ground-mounted solar panels for properties with large g
 
 ## How Do Solar Panel Perform In The Rain?
 
-It feels like we're never more than a day or two away from a rainy day in Manchester (although we were surprised to learn that [we're not even close to being the rainiest city](https://blog.scienceandindustrymuseum.org.uk/manchester-our-rainy-city/)!), but you might be surprised to learn that this isn't actually a problem for solar panel set ups. In fact, the rain helps keep the panels clean, which _increases_ their efficiency!
+Manchester gets its share of rain, but [it's not actually one of the UK's rainiest cities](https://blog.scienceandindustrymuseum.org.uk/manchester-our-rainy-city/). Rain doesn't hurt solar performance: panels generate from daylight rather than direct sunshine, and rain helps keep them clean.
 
 ## Can I Just Get A Battery?
 


### PR DESCRIPTION
## Summary

- Replaced em-dashes (`—`) with regular hyphens (` - `) across all content pages in `src/pages/`, `src/services/`, and `src/locations/`. This matches the existing house style used elsewhere in the codebase.
- Rewrote the most obvious AI-sounding sections to use the grounded, factual tone already used on the Oldham/Saddleworth pages:
  - `pages/ev-charger-relocation-manchester.md`: removed "It's not just convenient. It's better technically:"
  - `services/solar-and-battery-installations/middleton.md`: rewrote the page (had AI headers like "Unlock Your Home's Energy Potential" and "Transform Your Energy Future")
  - `services/solar-and-battery-installations/altrincham.md`: removed "Don't let Manchester's rainy reputation fool you!" and "we've got you covered"
  - `services/solar-and-battery-installations/blackley.md`: removed "We're not just another solar company - we're your neighbours" and "the opposite is actually the case"
  - `services/solar-and-battery-installations/bury.md`: removed "navigate planning considerations" and the "consistently exceed expectations" line
  - `services/solar-and-battery-installations/whitefield.md`: tightened the rain paragraph
  - `services/solar-and-battery-installations/failsworth.md`: removed "In fact" filler
  - `services/electric-vehicle-charger-installations/bury.md`: removed "seamless integration with renewable energy systems"
  - `services/electrical-safety-inspections-eicr/bolton.md` and EV charger Bolton page: removed "housing landscape"

Customer testimonials/quoted reviews were left untouched.

## Test plan

- [ ] Visually scan the modified pages in a preview build to confirm punctuation reads naturally
- [ ] Confirm `grep -rn "—" src/pages src/services src/locations` returns no results

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWGGjicqSjyAt55jthDKrY)_