### PR TITLE
Rewrite 11 EICR location pages to VOICE.md tone

### DIFF
--- a/src/services/electrical-safety-inspections-eicr/altrincham.md
+++ b/src/services/electrical-safety-inspections-eicr/altrincham.md
@@ -11,21 +11,21 @@ tags: [altrincham, eicr]
 
 # EICR Electrical Safety Inspections in Altrincham
 
-We do EICR electrical safety inspections across Altrincham at £150 plus VAT for any domestic property, with the certificate issued the same day.
+We do EICR electrical safety inspections across Altrincham at £150 plus VAT for any domestic property, with the certificate issued the same day. Ashley is NAPIT-registered (66870) and has been doing this around twenty years.
 
 ## Altrincham properties
 
 Altrincham has a wide spread of property types - period houses through the centre and out towards Bowdon, modern apartment conversions, and newer developments around the edges, and we've inspected most of it. The period properties commonly have electrical systems that have been extended in stages over the decades. What was originally put in for gas lighting has had electric showers, washing machines and the rest of modern life added on top, and whether the consumer unit and the earthing have kept pace tends to be the question.
 
-For listed buildings and properties in the conservation areas around South Hale and Bowdon, the inspection works the same way - we just take the access and aesthetic constraints into account when looking at routing and where the consumer unit sits.
+For properties in the conservation areas around South Hale and Bowdon, the inspection works the same way - we just take the access and aesthetic constraints into account when looking at routing and where the consumer unit sits.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to get those sorted.
 
 ## For buyers
 
-Get an EICR done before completion. With Altrincham property values where they are, the cost of finding out the consumer unit needs replacing or the earthing isn't up to standard is well worth knowing before money changes hands rather than after, and the report gives you something concrete to negotiate with.
+Get an EICR done before completion. With property values in Altrincham where they are, finding out after the fact that the consumer unit needs replacing or the earthing isn't up to standard is an expensive way to learn it - the report gives you something concrete to go back to the seller with before money changes hands.
 
 ## What's included
 

--- a/src/services/electrical-safety-inspections-eicr/bolton.md
+++ b/src/services/electrical-safety-inspections-eicr/bolton.md
@@ -11,22 +11,22 @@ tags: [bolton, eicr]
 
 # EICR Electrical Safety Inspections in Bolton
 
-We do EICR electrical safety inspections across Bolton at £150 plus VAT for any domestic property, with the certificate issued the same day. We're around twenty minutes down the road in Prestwich.
+We do EICR electrical safety inspections across Bolton at £150 plus VAT for any domestic property, with the certificate issued the same day. We're around twenty minutes down the road in Prestwich - Ashley is NAPIT-registered (66870) with around twenty years on the tools.
 
 ## Bolton properties
 
-Bolton's housing stock reflects its mill-town history, with terraced and semi-detached properties making up around 70% of the borough. We've inspected properties across Farnworth, Great Lever, Tonge Moor and Deane, and out towards the larger homes around Bromley Cross and Egerton. The terraces commonly have electrical systems that have been added to in pieces over the decades, with consumer units and earthing that don't always reflect current regulations. The larger properties out towards Bromley Cross and Egerton tend to have had more recent rewires, but installation quality varies depending on who did the work.
+Bolton's housing stock reflects its mill-town past, with terraced and semi-detached properties making up the bulk of the borough. We've inspected properties across Farnworth, Great Lever, Tonge Moor and Deane, and out towards the larger homes around Bromley Cross and Egerton. The terraces commonly have electrical systems that have been added to in pieces over the decades - consumer units and earthing arrangements that don't always reflect current regulations, and circuits that were never designed for the demands of modern life. The larger properties towards the north of the borough tend to have had more recent work done, but installation quality varies a fair bit depending on who did it.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to sort them.
 
 ## For buyers
 
-Get an EICR before completion. £150 is a small outlay against the cost of finding out the consumer unit needs replacing or the wiring isn't up to standard, and the report gives you something concrete to take back to the seller.
+Get an EICR before completion. £150 is a small outlay against the cost of finding out the consumer unit needs replacing or the wiring isn't up to standard after you've moved in, and the report gives you something concrete to take back to the seller.
 
 ## What's included
 
-The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day. If we find work that needs doing, we can quote for that and schedule it in.
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
 [Book an EICR inspection in Bolton](/contact/).

--- a/src/services/electrical-safety-inspections-eicr/bury.md
+++ b/src/services/electrical-safety-inspections-eicr/bury.md
@@ -11,15 +11,15 @@ tags: [bury, eicr]
 
 # EICR Electrical Safety Inspections in Bury
 
-We do EICR electrical safety inspections across Bury at £150 plus VAT for any domestic property, with the certificate issued the same day. We're about fifteen minutes down the road in Prestwich.
+We do EICR electrical safety inspections across Bury at £150 plus VAT for any domestic property, with the certificate issued the same day. We're about fifteen minutes down the road in Prestwich - Ashley is NAPIT-registered (66870) with around twenty years of experience.
 
 ## Bury properties
 
-Bury has a wide spread of property types - older terraces closer to the town centre, larger semis and detached homes out towards Tottington and Ramsbottom, and newer estates around the edges. The terraces commonly have electrical systems that have been added to gradually over the decades, with consumer units and earthing arrangements that don't always reflect current regulations. The newer estates tend to be more straightforward, but installation quality varies depending on the builder.
+Bury has a wide spread of property types - older terraces closer to the town centre, larger semis and detached homes out towards Tottington and Ramsbottom, and newer estates around the edges. The terraces commonly have electrical systems that have been added to gradually over the decades, with consumer units and earthing arrangements that don't always reflect current regulations. The properties out towards Ramsbottom and Tottington tend to be in better electrical shape on the whole, but there's a fair bit of variation depending on when the last significant work was done and who did it.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to sort those.
 
 ## For buyers
 
@@ -27,6 +27,6 @@ Get an EICR before completion. If we find issues like an outdated consumer unit 
 
 ## What's included
 
-The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day. If we find work that needs doing, we can quote for that and schedule it in.
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
 [Book an EICR inspection in Bury](/contact/).

--- a/src/services/electrical-safety-inspections-eicr/hale.md
+++ b/src/services/electrical-safety-inspections-eicr/hale.md
@@ -9,68 +9,26 @@ tags: [hale, eicr]
 
 # EICR Electrical Safety Inspections in Hale
 
-Professional electrical safety inspections in Hale from NAPIT-registered electricians. £150 plus VAT for all domestic properties with same day certificates - regardless of property size.
+We do EICR electrical safety inspections across Hale at £150 plus VAT for any domestic property, with the certificate issued the same day. The price doesn't change with property size - it's the same whether you're in a two-bed semi or a six-bed detached. Ashley is NAPIT-registered (66870) and has around twenty years of experience.
 
-## £150 plus VAT for any domestic property
+## Hale properties
 
-**Fixed price of £150 plus VAT for any domestic property in Hale** - whether you're in a 3-bed semi or a 6-bed detached with 10,000 square feet, the price doesn't change.
+Hale has a mix of period properties and larger modern homes. The older properties around Hale village commonly have electrical systems that have evolved over decades - what was originally designed for basic lighting loads has been extended over the years to handle the demands of modern life, and whether the consumer unit, the earthing and the bonding have kept up tends to be what the inspection works out. For properties in the conservation areas around South Hale and Hale Station, we just take the access constraints into account.
 
-Some competitors charge £250-350 for larger properties. Our flat rate means significant savings for Hale homeowners with bigger properties.
+Larger modern properties might seem like they'd be straightforward, but we find faults in relatively recent builds more often than you'd expect - loose connections, missing earthing, work that was done quickly and not checked properly at the time.
 
-We provide same day certificates and can usually fit you in quickly. EICR inspections are easier to schedule than major electrical work, so we can often accommodate requests at short notice.
+## For landlords
 
-**[Need an EICR in Hale? Get in touch today](/contact/)**
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to sort them.
 
-## Hale's property types
+## For buyers
 
-Hale has a mix of period properties and larger modern homes, each with different electrical considerations.
+Get an EICR before completion. Solicitors and buyers ask for them regularly now, and with Hale's property values, finding out after you've moved in that the consumer unit needs replacing or there's earthing work required is a more expensive surprise than it needs to be. The report gives you something concrete to go back to the seller with if anything comes up.
 
-**Period properties** around Hale village often have electrical systems that have evolved over decades. Original installations designed for basic lighting have been extended to cope with modern demands - electric showers, washing machines, tumble dryers, and all the gadgets we rely on today.
+## What's included
 
-**Larger modern properties** might seem like they'd be problem-free, but research shows 1 in 5 new builds still have electrical faults. Poor workmanship during rushed construction phases can create issues that only show up during proper testing.
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
-**Conservation area properties** around South Hale and Hale Station may have had electrical work done with particular constraints. We understand the specific challenges these properties present.
+We also cover [Hale Barns](/services/electrical-safety-inspections-eicr/hale-barns/) and [Altrincham](/services/electrical-safety-inspections-eicr/altrincham/) nearby.
 
-## For Hale landlords
-
-With Hale's strong rental market, landlords need to stay on top of electrical safety compliance. **EICR every 5 years plus one for each new tenant** - it's not optional.
-
-Penalties for non-compliance are serious - fines up to £30,000, plus local authorities can arrange costly remedial work and bill you for it. Give existing tenants the report within 28 days, new tenants before they move in.
-
-## For Hale property buyers
-
-**Get an EICR before any money changes hands.** Hale's property prices mean electrical problems can be expensive surprises you don't want.
-
-Prospective buyers and solicitors are now asking for EICRs. It's not a legal requirement, but people want the confidence that the electrics are safe before committing to a purchase.
-
-If we find issues like an outdated consumer unit or inadequate earthing (common in older properties), you can negotiate repair costs off the purchase price. Much better than discovering you need a rewiring job after completion.
-
-## Comprehensive EICR testing
-
-**Visual inspection** covers all visible wiring, switches, sockets, and your consumer unit. We check for damage, signs of overheating, and general condition.
-
-**Detailed electrical testing** using calibrated equipment includes continuity testing, insulation resistance measurement, earth fault loop impedance testing, and RCD operation checks. This is proper technical assessment, not just a quick visual check.
-
-**Same day certification** - you get your EICR certificate and comprehensive report explaining any findings in terms that make sense.
-
-## When we find issues
-
-**No pressure, just clear explanations.** If we discover problems, we explain what's wrong, why it matters, and what needs doing. You get honest quotes for any remedial work without inflated prices or unnecessary extras.
-
-We can handle any electrical issues discovered during inspection. Why complicate things by involving multiple contractors? Remedial work gets scheduled quickly.
-
-**[Need electrical work sorted after an inspection? We cover all electrical services](/services/)**
-
-## Hale EICR questions
-
-**Is it really £150 for any size property?** Yes. Whether you're in a compact cottage or a substantial family home, the price is £150 plus VAT.
-
-**How quickly can you schedule an inspection?** Usually within a few days. Hale is well within our regular coverage area.
-
-**Do you work with estate agents and solicitors?** We work with buyers, sellers, landlords, and tenants throughout Hale. Professional service that estate agents and solicitors trust.
-
-## Nearby areas
-
-We also cover [Hale Barns](/services/electrical-safety-inspections-eicr/hale-barns/), [Altrincham](/services/electrical-safety-inspections-eicr/altrincham/), Bowdon, and surrounding areas.
-
-**[Book your Hale EICR inspection today](/contact/)**
+[Book an EICR inspection in Hale](/contact/).

--- a/src/services/electrical-safety-inspections-eicr/middleton.md
+++ b/src/services/electrical-safety-inspections-eicr/middleton.md
@@ -11,22 +11,22 @@ tags: [middleton, eicr]
 
 # EICR Electrical Safety Inspections in Middleton
 
-We do EICR electrical safety inspections across Middleton at £150 plus VAT for any domestic property, with the certificate issued the same day. We're a few minutes down the road in Prestwich.
+We do EICR electrical safety inspections across Middleton at £150 plus VAT for any domestic property, with the certificate issued the same day. We're a few minutes down the road in Prestwich - Ashley is NAPIT-registered (66870) and has been on the tools around twenty years.
 
 ## Middleton properties
 
-Middleton has a mix of post-war semis, more recent estates, and older terraced housing closer to the town centre. The terraces commonly have electrical systems that have been added to in pieces over the years - what was originally put in for basic lighting has had a fair bit of modern life bolted on since, and whether the consumer unit and earthing have kept up is what the inspection works out. The newer estates tend to be more straightforward, but installation quality varies depending on the builder.
+Middleton has a mix of post-war semis, more recent estates, and older terraced housing closer to the town centre. The terraces commonly have electrical systems that have been added to in pieces over the years - what was originally put in for basic lighting has had a fair bit of modern life bolted on since, and whether the consumer unit and the earthing have kept up is what the inspection works out. The newer estates tend to be more straightforward, though installation quality varies depending on the builder and whether any extensions or alterations have been done since.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to get them sorted.
 
 ## For buyers
 
-Get an EICR before completion. £150 is a small outlay against the cost of finding out the consumer unit needs replacing once you've moved in, and the report gives you something concrete to take back to the seller.
+Get an EICR before completion. £150 is a small outlay against the cost of finding out the consumer unit needs replacing or there's earthing work required after you've moved in, and the report gives you something concrete to take back to the seller.
 
 ## What's included
 
-The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day. If we find work that needs doing, we can quote for that and schedule it in.
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
 [Book an EICR inspection in Middleton](/contact/).

--- a/src/services/electrical-safety-inspections-eicr/oldham.md
+++ b/src/services/electrical-safety-inspections-eicr/oldham.md
@@ -9,60 +9,24 @@ tags: [oldham, eicr]
 
 # EICR Electrical Safety Inspections in Oldham
 
-Professional electrical safety inspections across the Oldham borough from experienced NAPIT-registered electricians. £150 plus VAT for all domestic properties - same day certificates, no waiting around.
+We do EICR electrical safety inspections across the Oldham borough at £150 plus VAT for any domestic property, with the certificate issued the same day. We're about fifteen minutes from Prestwich - Ashley is NAPIT-registered (66870) with around twenty years of experience, and there are no travel charges.
 
-## Oldham's terraced housing stock
+## Oldham properties
 
-Nearly half of all properties in Oldham are terraced houses - many dating back to the mill era. These properties present specific electrical challenges that need proper assessment.
+Nearly half of all properties in Oldham are terraced, many of them going back to the mill era, and they tend to throw up the more interesting electrical situations. Systems that started out serving basic lighting loads in the 1900s have been added to in stages since - sometimes by the book, sometimes not - and what you end up with is worth checking properly. Consumer units that predate RCD protection are common across Chadderton, Royton, Shaw and central Oldham, and earthing arrangements that were adequate at the time don't always meet current standards.
 
-**Traditional terraced properties** throughout Chadderton, Royton, Shaw, and central Oldham often have electrical systems that have evolved over decades. Original installations designed for basic lighting have been extended to cope with modern electrical demands, but not always to the best standards.
+Out in Saddleworth and parts of Lees, the older stone-built properties have their own considerations - thicker walls, different construction methods, and earthing setups that can vary from what you'd expect in a standard brick terrace. The newer builds across the borough are generally more straightforward, though we do find faults in relatively recent properties more often than you'd expect.
 
-**Older stone-built properties** in Saddleworth and parts of Lees may have unique wiring configurations. Thicker walls and different construction methods mean earthing arrangements can differ from standard brick terraces.
+## For landlords
 
-**Modern developments** across the borough should be more straightforward, but even recent builds can have problems. Industry research shows electrical installation faults affect 1 in 5 new properties.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to sort those. If the consumer unit needs replacing, that work can be done alongside [solar panel installation](/services/solar-and-battery-installations/oldham/) to save on costs.
 
-## Our Oldham EICR Service - £150 plus VAT All Properties
+## For buyers
 
-**£150 plus VAT for any domestic property in Oldham** - whether you're in a compact terrace in Coldhurst or a detached home in Uppermill, the price stays the same. No travel charges from our Prestwich base.
+Get an EICR before completion. Oldham's terraced houses can look affordable on paper, but finding out after the fact that the consumer unit needs replacing or the earthing isn't up to standard adds up quickly - the report gives you something concrete to take back to the seller if anything comes up.
 
-Same day certificates and flexible scheduling. We can usually fit inspections in within a few days.
+## What's included
 
-**[Need an EICR in Oldham? Get in touch today](/contact/)**
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
-## For Oldham landlords
-
-Oldham has a significant buy-to-let market, particularly in central areas like St Mary's, Coldhurst, and Hollinwood. **EICR every 5 years plus one for each new tenant** - that's the legal requirement.
-
-Penalties for non-compliance are up to £30,000, plus local authorities can arrange remedial work and bill you for the costs. Give existing tenants the report within 28 days; new tenants get it before they move in.
-
-With the EPC C deadline coming in October 2030, many landlords are reviewing their properties anyway. An EICR is a good starting point - it tells you the condition of the electrical installation and whether upgrades are needed. If the consumer unit needs replacing, that work can be done alongside [solar panel installation](/services/solar-and-battery-installations/oldham/) to save on costs.
-
-## For property buyers
-
-**Get an EICR before any money changes hands.** Oldham's average terraced house price of £168,000 is affordable, but you don't want to discover a £2,000 electrical upgrade after you've moved in.
-
-If we find problems like an outdated consumer unit or inadequate earthing, you can use this information in purchase negotiations or make informed decisions about proceeding.
-
-## Thorough electrical testing
-
-**Comprehensive visual inspection** of all visible electrical installations, including wiring, switches, sockets, and consumer units. We check for damage, signs of overheating, and general condition.
-
-**Technical testing** using calibrated professional equipment - continuity testing, insulation resistance measurement, earth fault loop impedance testing, and RCD operation checks.
-
-**Same day documentation** - you receive your EICR certificate and detailed report explaining any findings in clear, understandable language.
-
-## When we find issues
-
-Straightforward assessment without pressure selling. If we discover electrical problems, we explain clearly what's wrong, why it matters, and what your options are. We can handle any remedial work discovered during inspection - no need to coordinate multiple contractors.
-
-**[Need electrical work after an inspection? We handle all electrical services](/services/)**
-
-## Oldham EICR questions
-
-**How quickly can you fit us in?** Usually within a few days. Oldham is well within our regular service area - we're just 13 minutes from Prestwich.
-
-**Any extra charges?** No travel charges - £150 plus VAT is the complete price for domestic EICR inspections across the Oldham borough.
-
-**Do you cover the whole borough?** Yes - Oldham town centre, Chadderton, Royton, Shaw, Lees, Saddleworth, Hollinwood, and everywhere in between.
-
-**[Ready to book your Oldham EICR inspection? Contact us today](/contact/)**
+[Book an EICR inspection in Oldham](/contact/).

--- a/src/services/electrical-safety-inspections-eicr/prestwich.md
+++ b/src/services/electrical-safety-inspections-eicr/prestwich.md
@@ -11,19 +11,19 @@ tags: [prestwich, eicr]
 
 # EICR Electrical Safety Inspections in Prestwich
 
-We're based in Prestwich, so this is essentially home turf. We do EICR electrical safety inspections across the area at £150 plus VAT for any domestic property, with the certificate issued the same day.
+We're based in Prestwich, so this is essentially home turf. We do EICR electrical safety inspections across the area at £150 plus VAT for any domestic property, with the certificate issued the same day. Ashley is NAPIT-registered (66870) and has been doing this around twenty years.
 
 ## Prestwich properties
 
-Prestwich has a strong mix of Victorian and Edwardian terraces - particularly around the village and out towards Heaton Park - alongside more recent housing. The older terraces commonly have electrical systems that have been added to in pieces over the decades. Original installations went in for gas lighting and minimal electrical demand, and what's been added since (washing machines, electric showers, the rest) hasn't always come with a corresponding upgrade to the consumer unit or the earthing.
+Prestwich has a strong mix of Victorian and Edwardian terraces - particularly around the village and out towards Heaton Park - alongside more recent housing. The older terraces commonly have electrical systems that have been added to in pieces over the decades. Original installations went in for gas lighting and minimal electrical demand, and what's been added since - washing machines, electric showers, the rest - hasn't always come with a corresponding upgrade to the consumer unit or the earthing. That's usually where the issues are.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in. If we find any C1, C2 or FI issues, you've got 28 days to put them right.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to put them right.
 
 ## For buyers
 
-Get an EICR before completion. With the mix of property ages around Prestwich, the inspection gives you a clear picture of whether you're walking into a straightforward installation or one that's going to want some work, and the report gives you something concrete to negotiate with.
+Get an EICR before completion. With the mix of property ages around Prestwich, the inspection gives you a clear picture of whether you're walking into a straightforward installation or one that's going to want some work, and the report gives you something concrete to negotiate with if anything does come up.
 
 ## What's included
 

--- a/src/services/electrical-safety-inspections-eicr/radcliffe.md
+++ b/src/services/electrical-safety-inspections-eicr/radcliffe.md
@@ -11,22 +11,22 @@ title: EICR Electrical Safety Inspections in Radcliffe | £150 plus VAT Same Day
 
 # EICR Electrical Safety Inspections in Radcliffe
 
-We do EICR electrical safety inspections across Radcliffe at £150 plus VAT for any domestic property, with the certificate issued the same day. We're a short run down the road in Prestwich.
+We do EICR electrical safety inspections across Radcliffe at £150 plus VAT for any domestic property, with the certificate issued the same day. We're a short run down the road in Prestwich - Ashley is NAPIT-registered (66870) with around twenty years of experience.
 
 ## Radcliffe properties
 
-Radcliffe has a mix of older terraced housing closer to the town centre and more recent family homes on the surrounding estates. The terraces commonly have electrical systems that have been added to gradually over the decades, with consumer units and earthing arrangements that don't always reflect current regulations. The newer estates tend to be more straightforward, but installation quality varies depending on the builder.
+Radcliffe has a mix of older terraced housing closer to the town centre - much of it going back to the late Victorian and Edwardian period - and more recent family homes on the surrounding estates. The terraces commonly have electrical systems that have been added to gradually over the decades, with consumer units and earthing arrangements that don't always reflect what's required now. The newer estates are generally more straightforward, but there's still a fair amount of variation depending on the builder and whether any extensions or alterations have been done since.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to sort those.
 
 ## For buyers
 
-Get an EICR before completion. If we find issues like an old consumer unit or earthing that needs work, you've got a basis for negotiating the purchase price, or for deciding whether to proceed at all.
+Get an EICR before completion. If we find issues like an old consumer unit or earthing that needs work, you've got something concrete to negotiate with before money changes hands, or a clear picture of what you're committing to.
 
 ## What's included
 
-The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day. If we find work that needs doing, we can quote for that and schedule it in.
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
 [Book an EICR inspection in Radcliffe](/contact/).

--- a/src/services/electrical-safety-inspections-eicr/stockport.md
+++ b/src/services/electrical-safety-inspections-eicr/stockport.md
@@ -11,22 +11,22 @@ tags: [stockport, eicr]
 
 # EICR Electrical Safety Inspections in Stockport
 
-We do EICR electrical safety inspections across Stockport at £150 plus VAT for any domestic property, with the certificate issued the same day. We're around half an hour up the M60 in Prestwich.
+We do EICR electrical safety inspections across Stockport at £150 plus VAT for any domestic property, with the certificate issued the same day. We're around half an hour up the M60 in Prestwich - Ashley is NAPIT-registered (66870) with around twenty years of experience.
 
 ## Stockport properties
 
-Stockport has a wide range of properties, from Victorian terraces near the centre to larger detached homes around the leafier suburbs and modern developments across the borough. The period properties commonly have electrical systems that have been upgraded in stages over the decades, with consumer units and earthing arrangements that don't always reflect current regulations. The newer developments tend to be more straightforward, but installation quality varies depending on the builder and the subcontractor.
+Stockport has a wide range of property types, from Victorian terraces in Heaton Moor and Reddish to larger detached homes in Cheadle Hulme and Bramhall, and newer apartment developments across the borough. The period properties commonly have electrical systems that have been upgraded in stages over the decades - the original installation has been added to as demands grew, and whether the consumer unit, the earthing and the bonding have all kept pace is usually what the inspection works out. The newer developments are generally more straightforward, but installation quality varies depending on the builder and the subcontractors used.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to sort them.
 
 ## For buyers
 
-Get an EICR before completion. With Stockport's spread of property values and ages, the inspection gives you a clear picture of whether you're walking into a straightforward setup or one that's going to want some work, and the report gives you something concrete to negotiate with.
+Get an EICR before completion. With Stockport's spread of property ages and values, the inspection gives you a clear picture of whether you're walking into a straightforward installation or one that's going to want some work, and the report gives you something concrete to go back to the seller with.
 
 ## What's included
 
-The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day. If we find work that needs doing, we can quote for that and schedule it in.
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
 [Book an EICR inspection in Stockport](/contact/).

--- a/src/services/electrical-safety-inspections-eicr/trafford.md
+++ b/src/services/electrical-safety-inspections-eicr/trafford.md
@@ -11,24 +11,24 @@ tags: [trafford, eicr]
 
 # EICR Electrical Safety Inspections in Trafford
 
-We do EICR electrical safety inspections across Trafford at £150 plus VAT for any domestic property, with the certificate issued the same day.
+We do EICR electrical safety inspections across Trafford at £150 plus VAT for any domestic property, with the certificate issued the same day. Ashley is NAPIT-registered (66870) and has around twenty years of experience.
 
 ## Trafford properties
 
-Trafford has a wide spread of property types - period properties through Hale, Bowdon and Altrincham, larger detached homes across the leafier areas, and modern apartments and developments. The period properties commonly have electrical systems that have been upgraded in stages over the decades, often alongside extensive renovation work that adds complexity to the inspection. The inspection works out whether the consumer unit, the earthing and the bonding have all kept pace with everything that's been added.
+Trafford has a wide spread of property types - period houses through Hale, Bowdon and Sale, larger detached homes across the leafier parts of the borough, modern apartments in Old Trafford and Stretford, and newer developments across Urmston and beyond. The period properties commonly have electrical systems that have been upgraded in stages, often alongside substantial renovation work, and what the inspection works out is whether the consumer unit, the earthing and the bonding have all kept pace with everything that's been added over the years.
 
-The newer developments tend to be more straightforward, but installation quality varies, and the higher-end developments aren't immune to that.
+The newer developments tend to be more straightforward, though installation quality varies across the borough, and the higher-value properties aren't immune to shoddy workmanship.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to sort them.
 
 ## For buyers
 
-Get an EICR before completion. With the property values across Trafford, £150 is a small outlay against the cost of finding out after you've moved in that the wiring or the consumer unit needs serious work, and the report gives you something concrete to take back to the seller.
+Get an EICR before completion. With the property values across Trafford, £150 is a small outlay against the cost of finding out after you've moved in that the wiring or the consumer unit needs serious work, and the report gives you something concrete to go back to the seller with.
 
 ## What's included
 
-The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day. If we find work that needs doing, we can quote for that and schedule it in.
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
 [Book an EICR inspection in Trafford](/contact/).

--- a/src/services/electrical-safety-inspections-eicr/whitefield.md
+++ b/src/services/electrical-safety-inspections-eicr/whitefield.md
@@ -11,22 +11,22 @@ tags: [whitefield, eicr]
 
 # EICR Electrical Safety Inspections in Whitefield
 
-We do EICR electrical safety inspections across Whitefield at £150 plus VAT for any domestic property, with the certificate issued the same day. We're just down the road in Prestwich.
+We do EICR electrical safety inspections across Whitefield at £150 plus VAT for any domestic property, with the certificate issued the same day. We're just down the road in Prestwich - Ashley is NAPIT-registered (66870) and has been doing this around twenty years.
 
 ## Whitefield properties
 
-Whitefield has a mix of Victorian and Edwardian terraces around the centre, post-war semis around Besses, and newer developments on the edges. The older terraces commonly have electrical systems that have been added to gradually over the decades, with consumer units and earthing arrangements that don't always reflect current regulations. The newer estates tend to be more straightforward, but installation quality varies depending on the builder.
+Whitefield has a mix of Victorian and Edwardian terraces around the centre and along some of the older roads, post-war semis around Besses o' th' Barn and Hillock, and newer developments on the edges. The older terraces commonly have electrical systems that have been extended in stages - what went in for gas lighting and basic demands has had a fair bit of modern electrical load added since, and the consumer unit and earthing don't always reflect that. The post-war semis tend to be more straightforward, but there's a reasonable amount of variation in what we find depending on whether they've been properly updated at any point.
 
 ## For landlords
 
-Landlords need an EICR every five years plus one for each new tenant. Fines for non-compliance run up to £30,000, and the local authority can have remedial work carried out and bill it back to you. Existing tenants need the report within 28 days; new tenants get it before they move in.
+Landlords are legally required to have an EICR every five years and one for each new tenancy. Fines for non-compliance run up to £30,000, and the local authority can arrange remedial work and bill you for it. Existing tenants need the report within 28 days; new tenants get it before they move in. If the inspection turns up C1, C2 or FI issues, you've got 28 days to sort those.
 
 ## For buyers
 
-Get an EICR before completion. If we find issues like an outdated consumer unit or earthing that needs bringing up to standard, you've got a basis for negotiating the purchase price, or grounds to walk away.
+Get an EICR before completion. If we find issues like an outdated consumer unit or earthing that needs bringing up to standard, you've got a basis for negotiating the purchase price, or grounds to walk away if the work needed is more than you bargained for.
 
 ## What's included
 
-The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day. If we find work that needs doing, we can quote for that and schedule it in.
+The inspection covers a full visual check of wiring, sockets, switches and the consumer unit, then calibrated technical testing for continuity, insulation resistance, earth fault loop impedance and RCD operation. The certificate and report are issued the same day, written in plain English. If we find work that needs doing, we can quote for that and schedule it in.
 
 [Book an EICR inspection in Whitefield](/contact/).


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Rewrites altrincham, bolton, bury, stockport, oldham, prestwich, whitefield, middleton, trafford, radcliffe, and hale EICR location pages
- Removes bold CTAs, FAQ sections, and fragment sentences - particularly heavy in hale.md and oldham.md which had drifted furthest from the house voice
- Flattens over-sectioned pages back to a clean four-section structure: local context → landlords → buyers → what's included
- Every page now consistently addresses the core searcher questions: price (£150+VAT), qualifications (NAPIT 66870, ~20 years), what's included, landlord legal obligations including the C1/C2/FI 28-day rule, buyer use case, and what happens if issues are found

## Voice changes

The pages that needed the most work (hale, oldham) had accumulated bold text for every key point, mid-page CTA links, FAQ sections, and the "No pressure, just clear explanations" type of copy that reads like it was written for a brochure. Those are gone. The simpler pages got lighter touches: NAPIT number and experience added to the intro, the C1/C2/FI 28-day obligation added to the landlord section, and "plain English" added to the what's-included section where it was missing.

## Test plan

- [ ] Check each page renders correctly on the site
- [ ] Confirm frontmatter (redirects, tags, icons) is unchanged
- [ ] Read aloud test: no sentences that sound like they belong on a brochure

https://claude.ai/code/session_01LTp2iZwMvZ3GDSaeyQbtit
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTp2iZwMvZ3GDSaeyQbtit)_